### PR TITLE
feat: ULID default IDs + fuzzy duplicate detection (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+
+## 0.2.0
+
+### Breaking — library API
+
+- **`Task.id` type changed from `number` → `string`.** All ID strategies now
+  return strings (sequential, timestamp, ULID). Library consumers iterating
+  task IDs must drop arithmetic on `task.id` (`task.id + 1`,
+  `Math.max(...tasks.map(t => t.id))` no longer behaves as expected).
+  Use `parseInt(task.id, 10)` if you need numeric comparison on a sequential
+  vault.
+
+### Breaking — defaults (CLI)
+
+- **Default ID strategy is now `ulid`** for new vaults. ULIDs are
+  collision-proof, lexicographically sortable, and require no counter file.
+- **Existing 0.1.x vaults are auto-detected as sequential** and will keep
+  producing `NNNN-*.md` filenames. The detection runs whether or not a
+  `.vault-tasks.toml` is present:
+  - No config file + existing `NNNN-*.md` files → sequential (with inferred
+    pad width).
+  - Config file with no explicit `[id] strategy` + existing `NNNN-*.md` files
+    → sequential (with inferred pad width).
+  - Empty vault → ULID.
+- **No data migration is performed.** Existing files are never renamed.
+- **Switching strategies is non-destructive.** Setting `[id] strategy = "ulid"`
+  in an existing sequential vault will keep all existing `NNNN-*` files
+  readable, findable, and listable. New tasks will get ULID filenames; the
+  vault becomes a mix. Lookup (`vt done 12`, `vt done 01HYX…`) handles both
+  formats. The orphaned `.vault-tasks-counter.json` can be deleted by hand.
+
+### Added
+
+- Fuzzy duplicate detection on `vt new` via trigram Dice similarity.
+  Configurable via `[task] dedupe_threshold` (0..1, default 0.5) and
+  `[task] dedupe_scan_limit` (most-recent N tasks scanned, default 500).
+  Suppress with `--no-dedupe`.
+- ULID prefix lookup: `vt done 01HYX` matches by ID prefix (≥ 4 chars).
+- `[id] strategy` is validated against the enum at config load time; typos
+  produce an actionable error naming the config file path.
+- Public exports: `generateUlid`, `isValidUlid`, `decodeTime`,
+  `parseTaskIdFromFilename`.
+
+### Fixed
+
+- Boolean CLI flags now correctly handle `--flag=value` form
+  (`--no-dedupe=true`, `--commit=false`). Previously the value was stored as
+  a string and the boolean check silently fell through.
+- `vt done 01` (or any short purely-digit identifier) on a ULID-only vault
+  now reports "No task matching" instead of silently editing an arbitrary
+  ULID task whose ID happens to start with `01`.
+- Strict task-file recognition: files like `notes-about-x.md` or `README.md`
+  in the backlog directory are no longer treated as tasks. ULIDs containing
+  Crockford ambiguity characters (I/L/O) are rejected.
+- Atomic `.gitignore` creation in `vt init` (no TOCTOU; never overwrites an
+  existing `.gitignore`).
+- Diacritic folding in similarity normalization. `"café résumé"` and
+  `"cafe resume"` now compare as identical.
+- ULID monotonic overflow no longer throws; bumps to next millisecond and
+  reseeds. Clock rewind (NTP step-back) no longer regresses the ID stream.
+- Ambiguous ID-match errors include next-step guidance (use more characters
+  or full filename).
+
+## 0.1.0
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ vt start 1
 vt done 1
 ```
 
-`vt init` creates a `.vault-tasks.toml` config and a `backlog/` directory. Tasks are markdown files like `0001-fix-login-redirect-bug.md`.
+`vt init` creates a `.vault-tasks.toml` config and a `backlog/` directory. Tasks are markdown files with ULID prefixes (e.g., `01HYX3KQPD7NG8RRGSSFQ9XNHY-fix-login-redirect-bug.md`). Sequential numeric IDs (`0001-...`) are also supported via config.
 
 ## Commands
 
@@ -56,7 +56,7 @@ vt done 1
 | `vt init` | Initialize config and backlog directory |
 | `vt install-skills` | Install Claude Code skills and rules. `--install`, `--list`, `--update` |
 
-Task lookup (`<id>`) accepts a numeric ID or a substring match against the filename.
+Task lookup (`<id>`) accepts a ULID prefix (e.g., `vt done 01HYX`), a numeric ID for sequential vaults (e.g., `vt done 1`), or a substring match against the filename (e.g., `vt done login`).
 
 ## Task format
 
@@ -107,8 +107,8 @@ archive_dir = "archive"           # relative to backlog_dir
 # auto_archive = true
 
 [id]
-# strategy = "sequential"         # "sequential" | "timestamp" | "ulid"
-# pad_width = 4                   # zero-pad width for sequential IDs
+# strategy = "ulid"               # "ulid" | "sequential" | "timestamp"
+# pad_width = 4                   # zero-pad width (only used with sequential)
 
 [slugify]
 # max_length = 60

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-tasks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Markdown-file task manager for solo devs building with Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ Options (vary by command):
   --tags, -t            Comma-separated tags
   --source, -s          Where this was noticed
   --commit              Git commit after creating
+  --no-dedupe           Skip duplicate detection (new)
   --status              Filter or set status
   --tag                 Filter by tag
   --all, -a             Include done/archived tasks (list, search)
@@ -47,7 +48,7 @@ Options (vary by command):
   --help, -h            Show this help message
 `;
 
-const BOOLEAN_FLAGS = new Set(["all", "commit", "install", "list", "update", "help"]);
+const BOOLEAN_FLAGS = new Set(["all", "commit", "install", "list", "update", "help", "no-dedupe"]);
 
 function isFlag(arg: string): boolean {
   if (arg.startsWith("--")) return true;
@@ -162,6 +163,7 @@ function main(): void {
           tags: args["tags"] as string | undefined,
           source: args["source"] as string | undefined,
           commit: args["commit"] === true,
+          noDedupe: args["no-dedupe"] === true,
         });
         break;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,7 +76,23 @@ function parseArgs(argv: string[]): { command: string; args: Record<string, stri
 
     if (arg.startsWith("--") && arg.includes("=")) {
       const eqIdx = arg.indexOf("=");
-      args[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1);
+      const key = arg.slice(2, eqIdx);
+      const rawValue = arg.slice(eqIdx + 1);
+      if (BOOLEAN_FLAGS.has(key)) {
+        const lower = rawValue.toLowerCase();
+        if (lower === "true" || lower === "1" || lower === "") {
+          args[key] = true;
+        } else if (lower === "false" || lower === "0") {
+          args[key] = false;
+        } else {
+          throw new Error(
+            `Flag --${key} is boolean; expected true/false/1/0 but got '${rawValue}'. ` +
+            `Either pass --${key} on its own, or use --${key}=true / --${key}=false.`
+          );
+        }
+      } else {
+        args[key] = rawValue;
+      }
       i++;
       continue;
     }
@@ -128,7 +144,16 @@ function main(): void {
     return;
   }
 
-  const { command, args, positional } = parseArgs(rawArgs);
+  let command: string;
+  let args: Record<string, string | boolean>;
+  let positional: string[];
+  try {
+    ({ command, args, positional } = parseArgs(rawArgs));
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exitCode = 1;
+    return;
+  }
 
   // init doesn't need config
   if (command === "init") {
@@ -136,9 +161,17 @@ function main(): void {
     return;
   }
 
+  let config;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exitCode = 1;
+    return;
+  }
+
   // install-skills needs vault root but not necessarily a full config
   if (command === "install-skills") {
-    const config = loadConfig();
     cmdInstallSkills(config, {
       install: args["install"] === true,
       list: args["list"] === true,
@@ -146,8 +179,6 @@ function main(): void {
     });
     return;
   }
-
-  const config = loadConfig();
 
   try {
     switch (command) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { generateDefaultConfig } from "../config.js";
+import { generateDefaultConfig, loadConfig } from "../config.js";
 
 export function cmdInit(args: { dir?: string }): void {
   const root = resolve(args.dir ?? process.cwd());
@@ -20,17 +20,20 @@ export function cmdInit(args: { dir?: string }): void {
     console.log(`Created: backlog/`);
   }
 
-  // Ensure .vault-tasks-counter.json is gitignored
-  const gitignorePath = join(root, ".gitignore");
-  if (existsSync(gitignorePath)) {
-    const content = readFileSync(gitignorePath, "utf-8");
-    if (!content.includes(".vault-tasks-counter.json")) {
-      writeFileSync(gitignorePath, content.trimEnd() + "\n.vault-tasks-counter.json\n", "utf-8");
-      console.log("Updated: .gitignore (added .vault-tasks-counter.json)");
+  // Only add counter file to .gitignore for sequential ID strategy
+  const config = loadConfig(root);
+  if (config.idStrategy === "sequential") {
+    const gitignorePath = join(root, ".gitignore");
+    if (existsSync(gitignorePath)) {
+      const content = readFileSync(gitignorePath, "utf-8");
+      if (!content.includes(".vault-tasks-counter.json")) {
+        writeFileSync(gitignorePath, content.trimEnd() + "\n.vault-tasks-counter.json\n", "utf-8");
+        console.log("Updated: .gitignore (added .vault-tasks-counter.json)");
+      }
+    } else {
+      writeFileSync(gitignorePath, ".vault-tasks-counter.json\n", "utf-8");
+      console.log("Created: .gitignore");
     }
-  } else {
-    writeFileSync(gitignorePath, ".vault-tasks-counter.json\n", "utf-8");
-    console.log("Created: .gitignore");
   }
 
   console.log("\nvault-tasks initialized. Create your first task with:");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,47 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 import { generateDefaultConfig, loadConfig } from "../config.js";
+
+const COUNTER_IGNORE_LINE = ".vault-tasks-counter.json";
+
+/**
+ * Atomically ensure `.vault-tasks-counter.json` is listed in .gitignore.
+ *
+ * Uses `openSync(path, 'wx')` to create the file exclusively; on EEXIST we
+ * read and append only if the line is missing. This avoids the TOCTOU race
+ * between `existsSync` and `writeFileSync` and guarantees we never overwrite
+ * an existing `.gitignore`.
+ */
+function ensureCounterIgnored(gitignorePath: string): void {
+  try {
+    const fd = openSync(gitignorePath, "wx");
+    try {
+      writeFileSync(fd, `${COUNTER_IGNORE_LINE}\n`, "utf-8");
+    } finally {
+      closeSync(fd);
+    }
+    console.log("Created: .gitignore");
+    return;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+  }
+
+  const content = readFileSync(gitignorePath, "utf-8");
+  // Line-level match so we don't get fooled by "#.vault-tasks-counter.json" in a comment.
+  const lines = content.split(/\r?\n/).map((l) => l.trim());
+  if (lines.includes(COUNTER_IGNORE_LINE)) return;
+
+  const appended = content.endsWith("\n") ? content : content + "\n";
+  writeFileSync(gitignorePath, appended + `${COUNTER_IGNORE_LINE}\n`, "utf-8");
+  console.log(`Updated: .gitignore (added ${COUNTER_IGNORE_LINE})`);
+}
 
 export function cmdInit(args: { dir?: string }): void {
   const root = resolve(args.dir ?? process.cwd());
@@ -15,25 +56,14 @@ export function cmdInit(args: { dir?: string }): void {
   writeFileSync(configPath, generateDefaultConfig(), "utf-8");
   console.log(`Created: .vault-tasks.toml`);
 
-  if (!existsSync(backlogDir)) {
-    mkdirSync(backlogDir, { recursive: true });
-    console.log(`Created: backlog/`);
-  }
+  const backlogExisted = existsSync(backlogDir);
+  mkdirSync(backlogDir, { recursive: true });
+  if (!backlogExisted) console.log(`Created: backlog/`);
 
   // Only add counter file to .gitignore for sequential ID strategy
   const config = loadConfig(root);
   if (config.idStrategy === "sequential") {
-    const gitignorePath = join(root, ".gitignore");
-    if (existsSync(gitignorePath)) {
-      const content = readFileSync(gitignorePath, "utf-8");
-      if (!content.includes(".vault-tasks-counter.json")) {
-        writeFileSync(gitignorePath, content.trimEnd() + "\n.vault-tasks-counter.json\n", "utf-8");
-        console.log("Updated: .gitignore (added .vault-tasks-counter.json)");
-      }
-    } else {
-      writeFileSync(gitignorePath, ".vault-tasks-counter.json\n", "utf-8");
-      console.log("Created: .gitignore");
-    }
+    ensureCounterIgnored(join(root, ".gitignore"));
   }
 
   console.log("\nvault-tasks initialized. Create your first task with:");

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,6 +1,9 @@
 import { execFileSync } from "node:child_process";
 import type { Config } from "../config.js";
+import { similarity } from "../similarity.js";
 import { TaskStore } from "../store.js";
+
+const SIMILARITY_THRESHOLD = 0.5;
 
 export function cmdNew(
   config: Config,
@@ -10,12 +13,36 @@ export function cmdNew(
     tags?: string;
     source?: string;
     commit?: boolean;
+    noDedupe?: boolean;
   }
 ): void {
   const store = new TaskStore(config);
   const tags = args.tags
     ? args.tags.split(",").map((t) => t.trim())
     : [];
+
+  // Check for similar existing tasks before creating
+  if (!args.noDedupe) {
+    const existing = store.loadAll(true);
+    const similar: Array<{ title: string; id: string; score: number }> = [];
+
+    for (const task of existing) {
+      const score = similarity(args.title, task.title);
+      if (score >= SIMILARITY_THRESHOLD) {
+        similar.push({ title: task.title, id: task.id, score });
+      }
+    }
+
+    if (similar.length > 0) {
+      similar.sort((a, b) => b.score - a.score);
+      console.error("Warning: Similar tasks found:");
+      for (const { title, id, score } of similar) {
+        const pct = Math.round(score * 100);
+        console.error(`  [${id}] ${title} (${pct}% similar)`);
+      }
+      console.error("Creating anyway. Use --no-dedupe to suppress this check.\n");
+    }
+  }
 
   const task = store.create({
     title: args.title,

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,8 +3,6 @@ import type { Config } from "../config.js";
 import { similarity } from "../similarity.js";
 import { TaskStore } from "../store.js";
 
-const SIMILARITY_THRESHOLD = 0.5;
-
 export function cmdNew(
   config: Config,
   args: {
@@ -21,14 +19,16 @@ export function cmdNew(
     ? args.tags.split(",").map((t) => t.trim())
     : [];
 
-  // Check for similar existing tasks before creating
+  // Check for similar existing tasks before creating. Bounded by
+  // `dedupeScanLimit` so large archives don't turn every `vt new` into an
+  // O(N) disk walk.
   if (!args.noDedupe) {
-    const existing = store.loadAll(true);
+    const existing = store.loadRecent(config.dedupeScanLimit, true);
     const similar: Array<{ title: string; id: string; score: number }> = [];
 
     for (const task of existing) {
       const score = similarity(args.title, task.title);
-      if (score >= SIMILARITY_THRESHOLD) {
+      if (score >= config.dedupeThreshold) {
         similar.push({ title: task.title, id: task.id, score });
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,7 @@ const DEFAULTS: Config = {
   defaultStatus: "open",
   archiveStatuses: ["done", "wont-do"],
   autoArchive: true,
-  idStrategy: "sequential",
+  idStrategy: "ulid",
   padWidth: 4,
   slugMaxLength: 60,
   project: {
@@ -281,8 +281,8 @@ archive_dir = "archive"           # relative to backlog_dir
 # auto_archive = true
 
 [id]
-# strategy = "sequential"         # "sequential" | "timestamp" | "ulid"
-# pad_width = 4                   # zero-pad width for sequential IDs
+# strategy = "ulid"               # "ulid" | "sequential" | "timestamp"
+# pad_width = 4                   # zero-pad width (only used with sequential)
 
 [slugify]
 # max_length = 60

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,8 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
+
+export const ID_STRATEGIES = ["sequential", "timestamp", "ulid"] as const;
+export type IdStrategy = (typeof ID_STRATEGIES)[number];
 
 export interface Config {
   vaultRoot: string;
@@ -14,9 +17,11 @@ export interface Config {
   defaultStatus: string;
   archiveStatuses: string[];
   autoArchive: boolean;
-  idStrategy: "sequential" | "timestamp" | "ulid";
+  idStrategy: IdStrategy;
   padWidth: number;
   slugMaxLength: number;
+  dedupeThreshold: number;
+  dedupeScanLimit: number;
   project: {
     name: string;
     qualityCommand: string;
@@ -41,6 +46,8 @@ const DEFAULTS: Config = {
   idStrategy: "ulid",
   padWidth: 4,
   slugMaxLength: 60,
+  dedupeThreshold: 0.5,
+  dedupeScanLimit: 500,
   project: {
     name: "",
     qualityCommand: "",
@@ -175,6 +182,26 @@ export function parseToml(text: string): Record<string, unknown> {
 }
 
 /**
+ * Probe a backlog dir for legacy sequential IDs. Returns the widest zero-padded
+ * numeric prefix (pad width) if sequential-style files exist, else null.
+ *
+ * Used to keep existing 0.1.x vaults on the sequential strategy when no config
+ * file is present, rather than silently mixing ULID files alongside NNNN files.
+ */
+function detectLegacySequentialWidth(backlogDir: string): number | null {
+  if (!existsSync(backlogDir)) return null;
+  let widest = 0;
+  let found = false;
+  for (const name of readdirSync(backlogDir)) {
+    const m = name.match(/^(\d+)-.*\.md$/);
+    if (!m) continue;
+    found = true;
+    if (m[1].length > widest) widest = m[1].length;
+  }
+  return found ? widest : null;
+}
+
+/**
  * Load configuration by finding and parsing `.vault-tasks.toml`,
  * merged with defaults.
  */
@@ -183,14 +210,21 @@ export function loadConfig(startDir?: string): Config {
 
   if (!configFile) {
     const vaultRoot = resolve(startDir ?? process.cwd());
+    const backlogDir = resolve(vaultRoot, DEFAULTS.backlogDir);
+    // Keep legacy vaults (upgraded from 0.1.x without a config) on sequential
+    // so `vt new` keeps producing NNNN-* filenames instead of silently mixing
+    // ULIDs with the user's existing numbered tasks.
+    const legacyWidth = detectLegacySequentialWidth(backlogDir);
     return {
       ...DEFAULTS,
       vaultRoot,
-      backlogDir: resolve(vaultRoot, DEFAULTS.backlogDir),
+      backlogDir,
       archiveDir: resolve(vaultRoot, DEFAULTS.backlogDir, DEFAULTS.archiveDir),
       journalDir: resolve(vaultRoot, DEFAULTS.journalDir),
       projectsDir: resolve(vaultRoot, DEFAULTS.projectsDir),
       evergreenDir: resolve(vaultRoot, DEFAULTS.evergreenDir),
+      idStrategy: legacyWidth !== null ? "sequential" : DEFAULTS.idStrategy,
+      padWidth: legacyWidth !== null ? Math.max(legacyWidth, DEFAULTS.padWidth) : DEFAULTS.padWidth,
     };
   }
 
@@ -231,6 +265,45 @@ export function loadConfig(startDir?: string): Config {
     }
   }
 
+  const rawStrategy = id["strategy"];
+  let idStrategy: IdStrategy = DEFAULTS.idStrategy;
+  if (rawStrategy !== undefined) {
+    if (typeof rawStrategy !== "string" || !(ID_STRATEGIES as readonly string[]).includes(rawStrategy)) {
+      throw new Error(
+        `Invalid [id] strategy: ${JSON.stringify(rawStrategy)}. ` +
+        `Must be one of: ${ID_STRATEGIES.join(", ")}. ` +
+        `Edit ${configFile} to fix.`
+      );
+    }
+    idStrategy = rawStrategy as IdStrategy;
+  }
+
+  const rawThreshold = task["dedupe_threshold"];
+  let dedupeThreshold = DEFAULTS.dedupeThreshold;
+  if (rawThreshold !== undefined) {
+    const n = typeof rawThreshold === "number" ? rawThreshold : Number(rawThreshold);
+    if (!Number.isFinite(n) || n < 0 || n > 1) {
+      throw new Error(
+        `Invalid [task] dedupe_threshold: ${JSON.stringify(rawThreshold)}. ` +
+        `Must be a number between 0 and 1.`
+      );
+    }
+    dedupeThreshold = n;
+  }
+
+  const rawScanLimit = task["dedupe_scan_limit"];
+  let dedupeScanLimit = DEFAULTS.dedupeScanLimit;
+  if (rawScanLimit !== undefined) {
+    const n = typeof rawScanLimit === "number" ? rawScanLimit : Number(rawScanLimit);
+    if (!Number.isInteger(n) || n < 0) {
+      throw new Error(
+        `Invalid [task] dedupe_scan_limit: ${JSON.stringify(rawScanLimit)}. ` +
+        `Must be a non-negative integer.`
+      );
+    }
+    dedupeScanLimit = n;
+  }
+
   return {
     vaultRoot,
     backlogDir,
@@ -244,9 +317,11 @@ export function loadConfig(startDir?: string): Config {
     defaultStatus: (task["default_status"] as string) ?? DEFAULTS.defaultStatus,
     archiveStatuses: (task["archive_statuses"] as string[]) ?? DEFAULTS.archiveStatuses,
     autoArchive: (task["auto_archive"] as boolean) ?? DEFAULTS.autoArchive,
-    idStrategy: (id["strategy"] as Config["idStrategy"]) ?? DEFAULTS.idStrategy,
+    idStrategy,
     padWidth: (id["pad_width"] as number) ?? DEFAULTS.padWidth,
     slugMaxLength: (slug["max_length"] as number) ?? DEFAULTS.slugMaxLength,
+    dedupeThreshold,
+    dedupeScanLimit,
     project: {
       name: (project["name"] as string) ?? "",
       qualityCommand: (project["quality_command"] as string) ?? "",
@@ -279,6 +354,8 @@ archive_dir = "archive"           # relative to backlog_dir
 # default_status = "open"
 # archive_statuses = ["done", "wont-do"]
 # auto_archive = true
+# dedupe_threshold = 0.5            # similarity 0..1 for duplicate warnings on vt new
+# dedupe_scan_limit = 500           # most-recent N tasks scanned for duplicates (0 = unlimited)
 
 [id]
 # strategy = "ulid"               # "ulid" | "sequential" | "timestamp"

--- a/src/config.ts
+++ b/src/config.ts
@@ -266,7 +266,8 @@ export function loadConfig(startDir?: string): Config {
   }
 
   const rawStrategy = id["strategy"];
-  let idStrategy: IdStrategy = DEFAULTS.idStrategy;
+  let idStrategy: IdStrategy;
+  let inferredPadWidth: number | null = null;
   if (rawStrategy !== undefined) {
     if (typeof rawStrategy !== "string" || !(ID_STRATEGIES as readonly string[]).includes(rawStrategy)) {
       throw new Error(
@@ -276,6 +277,17 @@ export function loadConfig(startDir?: string): Config {
       );
     }
     idStrategy = rawStrategy as IdStrategy;
+  } else {
+    // No explicit strategy. Mirror the no-config-file branch: if existing
+    // NNNN-*.md files are present, stay on sequential to avoid silently
+    // mixing ULIDs into a vault that was running on 0.1.x defaults.
+    const legacyWidth = detectLegacySequentialWidth(backlogDir);
+    if (legacyWidth !== null) {
+      idStrategy = "sequential";
+      inferredPadWidth = legacyWidth;
+    } else {
+      idStrategy = DEFAULTS.idStrategy;
+    }
   }
 
   const rawThreshold = task["dedupe_threshold"];
@@ -318,7 +330,9 @@ export function loadConfig(startDir?: string): Config {
     archiveStatuses: (task["archive_statuses"] as string[]) ?? DEFAULTS.archiveStatuses,
     autoArchive: (task["auto_archive"] as boolean) ?? DEFAULTS.autoArchive,
     idStrategy,
-    padWidth: (id["pad_width"] as number) ?? DEFAULTS.padWidth,
+    padWidth:
+      (id["pad_width"] as number) ??
+      (inferredPadWidth !== null ? Math.max(inferredPadWidth, DEFAULTS.padWidth) : DEFAULTS.padWidth),
     slugMaxLength: (slug["max_length"] as number) ?? DEFAULTS.slugMaxLength,
     dedupeThreshold,
     dedupeScanLimit,

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from "node:child_process";
-import { randomInt } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { Config } from "./config.js";
+import { generateUlid } from "./ulid.js";
 
 /**
  * Scan backlog + archive directories for the highest numeric ID prefix.
@@ -72,7 +72,7 @@ function getCounterPath(config: Config): string {
  * TaskStore.create(), which uses exclusive file creation (wx flag) with retry
  * to detect and recover from collisions.
  */
-function getNextSequentialId(config: Config): number {
+function getNextSequentialId(config: Config): string {
   const fileMax = scanMaxId(config);
   const counterPath = getCounterPath(config);
 
@@ -92,13 +92,13 @@ function getNextSequentialId(config: Config): number {
     // Best effort — file scan fallback will still work
   }
 
-  return nextId;
+  return String(nextId);
 }
 
 /**
  * Generate a timestamp-based ID: YYYYMMDDHHMMss
  */
-function getTimestampId(): number {
+function getTimestampId(): string {
   const now = new Date();
   const parts = [
     now.getFullYear(),
@@ -108,53 +108,32 @@ function getTimestampId(): number {
     String(now.getMinutes()).padStart(2, "0"),
     String(now.getSeconds()).padStart(2, "0"),
   ];
-  return parseInt(parts.join(""), 10);
-}
-
-/**
- * Generate a ULID-like sortable ID (simplified: timestamp + random suffix).
- * Not a full ULID spec implementation, but collision-resistant and sortable.
- * Uses crypto.randomInt() for better randomness and validates safe integer range.
- */
-function getUlidId(): number {
-  // Use last 7 digits of timestamp (covers ~115 days) + 6 random digits = 13 digits max.
-  // Number.MAX_SAFE_INTEGER is 9007199254740991 (16 digits), so 13 digits is always safe.
-  // Retry loop guards against any edge case where the result is not a safe integer.
-  for (let attempt = 0; attempt < 10; attempt++) {
-    const timestamp = Date.now() % 10000000; // 7 digits
-    const random = randomInt(0, 1000000); // 6 digits: 0–999999
-    const id = parseInt(`${timestamp}${String(random).padStart(6, "0")}`, 10);
-    if (Number.isSafeInteger(id)) {
-      return id;
-    }
-  }
-  // Fallback: should never reach here, but return a safe value if it does
-  return Date.now() % 10000000000;
+  return parts.join("");
 }
 
 /**
  * Get the next task ID based on the configured strategy.
  */
-export function getNextId(config: Config): number {
+export function getNextId(config: Config): string {
   switch (config.idStrategy) {
     case "sequential":
       return getNextSequentialId(config);
     case "timestamp":
       return getTimestampId();
     case "ulid":
-      return getUlidId();
+      return generateUlid();
     default:
       return getNextSequentialId(config);
   }
 }
 
 /**
- * Format an ID for use in filenames, respecting pad width.
+ * Format an ID for use in filenames. For sequential, pads to padWidth.
+ * For timestamp and ULID, returns as-is (already formatted).
  */
-export function formatId(id: number, config: Config): string {
+export function formatId(id: string, config: Config): string {
   if (config.idStrategy === "sequential") {
-    return String(id).padStart(config.padWidth, "0");
+    return id.padStart(config.padWidth, "0");
   }
-  // Timestamp and ULID IDs are already long enough
-  return String(id);
+  return id;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { TaskStore } from "./store.js";
 export { loadConfig, findConfigFile } from "./config.js";
 export { parseFrontmatter, writeFrontmatter } from "./frontmatter.js";
 export { slugify } from "./slugify.js";
+export { generateUlid, isValidUlid } from "./ulid.js";

--- a/src/output.ts
+++ b/src/output.ts
@@ -25,11 +25,15 @@ export function sortByPriority(tasks: Task[]): Task[] {
 export function formatTaskTable(tasks: Task[]): string {
   if (tasks.length === 0) return "No tasks found.";
 
-  const header = `${"ID".padEnd(6)} ${"STATUS".padEnd(10)} ${"PRI".padEnd(8)} ${"CREATED".padEnd(12)} TASK`;
-  const divider = "-".repeat(70);
+  // Compute ID column width: max of actual IDs, capped at 10, minimum 4
+  const maxIdLen = Math.max(4, ...tasks.map((t) => t.id.length));
+  const idWidth = Math.min(maxIdLen, 10);
+
+  const header = `${"ID".padEnd(idWidth)} ${"STATUS".padEnd(10)} ${"PRI".padEnd(8)} ${"CREATED".padEnd(12)} TASK`;
+  const divider = "-".repeat(idWidth + 1 + 10 + 1 + 8 + 1 + 12 + 1 + 20);
 
   const rows = tasks.map((t) => {
-    const id = String(t.id).padEnd(6);
+    const id = t.id.slice(0, idWidth).padEnd(idWidth);
     const status = (STATUS_DISPLAY[t.status] ?? t.status).padEnd(10);
     const pri = t.priority.slice(0, 3).padEnd(8);
     const created = (t.created || "?").padEnd(12);
@@ -44,11 +48,14 @@ export function formatStaleTable(
 ): string {
   if (items.length === 0) return "No stale tasks found.";
 
-  const header = `${"ID".padEnd(6)} ${"AGE".padEnd(8)} ${"PRI".padEnd(8)} TASK`;
-  const divider = "-".repeat(60);
+  const maxIdLen = Math.max(4, ...items.map(({ task }) => task.id.length));
+  const idWidth = Math.min(maxIdLen, 10);
+
+  const header = `${"ID".padEnd(idWidth)} ${"AGE".padEnd(8)} ${"PRI".padEnd(8)} TASK`;
+  const divider = "-".repeat(idWidth + 1 + 8 + 1 + 8 + 1 + 20);
 
   const rows = items.map(({ task, ageDays }) => {
-    const id = String(task.id).padEnd(6);
+    const id = task.id.slice(0, idWidth).padEnd(idWidth);
     const age = String(ageDays).padEnd(8);
     const pri = task.priority.slice(0, 3).padEnd(8);
     return `${id} ${age} ${pri} ${task.title}`;

--- a/src/similarity.ts
+++ b/src/similarity.ts
@@ -1,0 +1,59 @@
+/**
+ * Zero-dependency trigram similarity for detecting duplicate task titles.
+ *
+ * Uses the Dice coefficient on character trigrams (3-char sliding windows).
+ * Handles word reordering naturally — "fix auth bug" ≈ "auth bug fix".
+ */
+
+/**
+ * Normalize a string for comparison: lowercase, strip punctuation, collapse whitespace.
+ */
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Generate the set of character trigrams from a string.
+ */
+function trigrams(s: string): Set<string> {
+  const result = new Set<string>();
+  const padded = ` ${s} `; // pad to capture word boundaries
+  for (let i = 0; i <= padded.length - 3; i++) {
+    result.add(padded.slice(i, i + 3));
+  }
+  return result;
+}
+
+/**
+ * Compute the Dice coefficient between two trigram sets.
+ * Returns a value between 0.0 (completely different) and 1.0 (identical).
+ */
+function diceCoefficient(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1.0;
+  if (a.size === 0 || b.size === 0) return 0.0;
+
+  let intersection = 0;
+  for (const gram of a) {
+    if (b.has(gram)) intersection++;
+  }
+
+  return (2 * intersection) / (a.size + b.size);
+}
+
+/**
+ * Compute similarity between two strings using trigram Dice coefficient.
+ * Returns a value between 0.0 (completely different) and 1.0 (identical).
+ */
+export function similarity(a: string, b: string): number {
+  const na = normalize(a);
+  const nb = normalize(b);
+
+  if (na === nb) return 1.0;
+  if (na.length === 0 || nb.length === 0) return 0.0;
+
+  return diceCoefficient(trigrams(na), trigrams(nb));
+}

--- a/src/similarity.ts
+++ b/src/similarity.ts
@@ -6,12 +6,17 @@
  */
 
 /**
- * Normalize a string for comparison: lowercase, strip punctuation, collapse whitespace.
+ * Normalize a string for comparison: lowercase, fold diacritics, strip
+ * punctuation, collapse whitespace. Uses Unicode letter/number classes so
+ * non-ASCII titles (e.g. "café résumé") still produce meaningful trigrams
+ * instead of degenerate empty strings.
  */
 function normalize(s: string): string {
   return s
+    .normalize("NFKD")
+    .replace(/\p{M}+/gu, "") // drop combining marks (diacritics)
     .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, "")
+    .replace(/[^\p{L}\p{N}\s]/gu, "")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,7 +29,7 @@ function fileToTask(filePath: string, text: string): Task {
   const { meta, body } = parseFrontmatter(text);
   const name = basename(filePath) ?? "";
   const stem = name.replace(/\.md$/, "");
-  const idMatch = name.match(/^(\d+)-/);
+  const idMatch = name.match(/^([0-9A-Za-z]+)-/);
 
   const extraMeta: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(meta)) {
@@ -49,7 +49,7 @@ function fileToTask(filePath: string, text: string): Task {
   }
 
   return {
-    id: idMatch ? parseInt(idMatch[1], 10) : 0,
+    id: idMatch ? idMatch[1] : "",
     title: String(meta["title"] ?? "") || stem,
     status: String(meta["status"] ?? "") || "open",
     priority: String(meta["priority"] ?? "") || "medium",
@@ -90,7 +90,7 @@ export class TaskStore {
   private listMdFiles(dir: string): string[] {
     if (!existsSync(dir)) return [];
     return readdirSync(dir)
-      .filter((f) => /^\d+-.*\.md$/.test(f))
+      .filter((f) => /^[0-9A-Za-z]+-.*\.md$/.test(f))
       .sort()
       .map((f) => join(dir, f));
   }
@@ -122,7 +122,7 @@ export class TaskStore {
       const filePath = join(this.config.backlogDir, filename);
 
       const task: Task = {
-        id,
+        id: idStr,
         title,
         status: this.config.defaultStatus,
         priority,
@@ -168,14 +168,31 @@ export class TaskStore {
   private matchInDir(identifier: string, dir: string): Task | null {
     const files = this.listMdFiles(dir);
 
-    // Try numeric ID first
+    // Try zero-padded numeric prefix match (backwards compat: `vt done 1` → `0001-...`)
     const numId = parseInt(identifier, 10);
-    if (!isNaN(numId)) {
+    if (!isNaN(numId) && String(numId) === identifier) {
       const prefix = String(numId).padStart(this.config.padWidth, "0") + "-";
       const match = files.find((f) => basename(f)?.startsWith(prefix));
       if (match) {
         return fileToTask(match, readFileSync(match, "utf-8"));
       }
+    }
+
+    // Try case-insensitive ID prefix match (handles ULID prefixes: `vt done 01HYX`)
+    const upperIdent = identifier.toUpperCase();
+    const prefixMatches = files.filter((f) => {
+      const name = basename(f) ?? "";
+      const fileId = name.match(/^([0-9A-Za-z]+)-/);
+      return fileId && fileId[1].toUpperCase().startsWith(upperIdent);
+    });
+    if (prefixMatches.length === 1) {
+      return fileToTask(prefixMatches[0], readFileSync(prefixMatches[0], "utf-8"));
+    }
+    if (prefixMatches.length > 1) {
+      const names = prefixMatches.map((m) => basename(m));
+      throw new Error(
+        `Ambiguous match for '${identifier}':\n${names.map((n) => `  ${n}`).join("\n")}`
+      );
     }
 
     // Substring match on filename

--- a/src/store.ts
+++ b/src/store.ts
@@ -25,11 +25,32 @@ const KNOWN_META_KEYS = new Set([
   "source",
 ]);
 
+// Strict ID prefix for a task filename. Matches:
+//   - Canonical ULID (26-char Crockford base32, no I/L/O/U)
+//   - Numeric prefix (sequential or 14-digit timestamp)
+// The `.md` suffix check is the caller's responsibility.
+//
+// Keeping this strict means non-task files (README.md, notes-about-x.md, etc.)
+// sitting in the backlog or archive directory don't silently get picked up by
+// listing, searching, ID lookup, or dedupe.
+const TASK_ID_RE = /^(\d+|[0-9A-HJKMNP-TV-Z]{26})-[^/]*\.md$/i;
+
+/** Return the ID prefix of a task filename, or null if it doesn't look like a task. */
+export function parseTaskIdFromFilename(name: string): string | null {
+  const m = name.match(TASK_ID_RE);
+  return m ? m[1] : null;
+}
+
+/** True if an identifier is a plausible ULID prefix (canonical Crockford, >= 4 chars). */
+function looksLikeUlidPrefix(s: string): boolean {
+  return s.length >= 4 && /^[0-9A-HJKMNP-TV-Z]+$/i.test(s) && !/^\d+$/.test(s);
+}
+
 function fileToTask(filePath: string, text: string): Task {
   const { meta, body } = parseFrontmatter(text);
-  const name = basename(filePath) ?? "";
+  const name = basename(filePath);
   const stem = name.replace(/\.md$/, "");
-  const idMatch = name.match(/^([0-9A-Za-z]+)-/);
+  const id = parseTaskIdFromFilename(name);
 
   const extraMeta: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(meta)) {
@@ -49,7 +70,7 @@ function fileToTask(filePath: string, text: string): Task {
   }
 
   return {
-    id: idMatch ? idMatch[1] : "",
+    id: id ?? "",
     title: String(meta["title"] ?? "") || stem,
     status: String(meta["status"] ?? "") || "open",
     priority: String(meta["priority"] ?? "") || "medium",
@@ -90,7 +111,7 @@ export class TaskStore {
   private listMdFiles(dir: string): string[] {
     if (!existsSync(dir)) return [];
     return readdirSync(dir)
-      .filter((f) => /^[0-9A-Za-z]+-.*\.md$/.test(f))
+      .filter((f) => parseTaskIdFromFilename(f) !== null)
       .sort()
       .map((f) => join(dir, f));
   }
@@ -165,40 +186,91 @@ export class TaskStore {
     return tasks;
   }
 
+  /**
+   * Load at most `limit` tasks, preferring the most recent. Filenames are
+   * time-sortable (ULID timestamp prefix or monotonic sequential ID), so
+   * alphabetic sort approximates chronological order.
+   *
+   * Used to bound O(N) dedupe scans on mature vaults. Pass `limit = 0` to
+   * disable the cap (equivalent to `loadAll(includeArchived)`).
+   */
+  loadRecent(limit: number, includeArchived = false): Task[] {
+    this.ensureBacklogDir();
+    const paths: string[] = [...this.listMdFiles(this.config.backlogDir)];
+    if (includeArchived) {
+      paths.push(...this.listMdFiles(this.config.archiveDir));
+    }
+    paths.sort();
+    const slice = limit > 0 ? paths.slice(-limit) : paths;
+    return slice.map((f) => fileToTask(f, readFileSync(f, "utf-8")));
+  }
+
   private matchInDir(identifier: string, dir: string): Task | null {
     const files = this.listMdFiles(dir);
 
-    // Try zero-padded numeric prefix match (backwards compat: `vt done 1` → `0001-...`)
-    const numId = parseInt(identifier, 10);
-    if (!isNaN(numId) && String(numId) === identifier) {
-      const prefix = String(numId).padStart(this.config.padWidth, "0") + "-";
-      const match = files.find((f) => basename(f)?.startsWith(prefix));
-      if (match) {
-        return fileToTask(match, readFileSync(match, "utf-8"));
+    const ambiguous = (matches: string[]): Error => {
+      const names = matches.map((m) => basename(m));
+      return new Error(
+        `Ambiguous match for '${identifier}' — ${matches.length} candidates:\n` +
+        `${names.map((n) => `  ${n}`).join("\n")}\n` +
+        `Use more characters of the ID, or the full filename stem.`
+      );
+    };
+
+    // 1. Purely-digit identifiers take the numeric branch exclusively. This
+    //    prevents a short string like "01" (parseInt = 1, not a valid numeric
+    //    match) from silently falling through to the ULID-prefix branch and
+    //    returning an arbitrary ULID task whose ID happens to start with "01"
+    //    (which is true for virtually every ULID from 2016–2039).
+    if (/^\d+$/.test(identifier)) {
+      const numId = parseInt(identifier, 10);
+      if (Number.isSafeInteger(numId)) {
+        // Accept the identifier as typed (e.g. "0001-*") and also zero-padded
+        // to padWidth (so "1" finds "0001-*" with padWidth=4).
+        const candidatePrefixes = new Set<string>([
+          `${identifier}-`,
+          `${String(numId).padStart(this.config.padWidth, "0")}-`,
+        ]);
+        const numericMatches = files.filter((f) => {
+          const name = basename(f);
+          for (const p of candidatePrefixes) {
+            if (name.startsWith(p)) return true;
+          }
+          return false;
+        });
+        if (numericMatches.length === 1) {
+          return fileToTask(numericMatches[0], readFileSync(numericMatches[0], "utf-8"));
+        }
+        if (numericMatches.length > 1) {
+          throw ambiguous(numericMatches);
+        }
+      }
+      // Deliberately do NOT fall through to the ULID-prefix branch: a digit-only
+      // identifier is unambiguously a numeric ID request, and silently matching
+      // a ULID that happens to share the same digit prefix would be a data bug.
+      return null;
+    }
+
+    // 2. ULID prefix match (case-insensitive). Requires at least 4 characters
+    //    of canonical Crockford base32 to avoid trivial collisions.
+    if (looksLikeUlidPrefix(identifier)) {
+      const upperIdent = identifier.toUpperCase();
+      const prefixMatches = files.filter((f) => {
+        const fileId = parseTaskIdFromFilename(basename(f));
+        return fileId !== null && fileId.toUpperCase().startsWith(upperIdent);
+      });
+      if (prefixMatches.length === 1) {
+        return fileToTask(prefixMatches[0], readFileSync(prefixMatches[0], "utf-8"));
+      }
+      if (prefixMatches.length > 1) {
+        throw ambiguous(prefixMatches);
       }
     }
 
-    // Try case-insensitive ID prefix match (handles ULID prefixes: `vt done 01HYX`)
-    const upperIdent = identifier.toUpperCase();
-    const prefixMatches = files.filter((f) => {
-      const name = basename(f) ?? "";
-      const fileId = name.match(/^([0-9A-Za-z]+)-/);
-      return fileId && fileId[1].toUpperCase().startsWith(upperIdent);
-    });
-    if (prefixMatches.length === 1) {
-      return fileToTask(prefixMatches[0], readFileSync(prefixMatches[0], "utf-8"));
-    }
-    if (prefixMatches.length > 1) {
-      const names = prefixMatches.map((m) => basename(m));
-      throw new Error(
-        `Ambiguous match for '${identifier}':\n${names.map((n) => `  ${n}`).join("\n")}`
-      );
-    }
-
-    // Substring match on filename
+    // 3. Substring match on filename stem.
     const query = identifier.toLowerCase();
     const matches = files.filter((f) => {
-      const name = basename(f)?.replace(/\.md$/, "") ?? "";
+      const name = basename(f).replace(/\.md$/, "");
       return name.toLowerCase().includes(query);
     });
 
@@ -206,10 +278,7 @@ export class TaskStore {
       return fileToTask(matches[0], readFileSync(matches[0], "utf-8"));
     }
     if (matches.length > 1) {
-      const names = matches.map((m) => basename(m));
-      throw new Error(
-        `Ambiguous match for '${identifier}':\n${names.map((n) => `  ${n}`).join("\n")}`
-      );
+      throw ambiguous(matches);
     }
 
     return null;

--- a/src/task.ts
+++ b/src/task.ts
@@ -6,7 +6,7 @@
  * that vault-tasks doesn't manage (e.g. `due`, `assignee`).
  */
 export interface Task {
-  id: number;
+  id: string;
   title: string;
   status: string;
   priority: string;

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { parseFrontmatter } from "../frontmatter.js";
@@ -334,7 +334,13 @@ describe("CLI with ULID strategy", () => {
 
   it("init creates config with ulid as default", () => {
     const config = readFileSync(join(dir, ".vault-tasks.toml"), "utf-8");
-    assert.ok(config.includes("ulid"));
+    // Must document ulid as the canonical strategy value in the [id] section.
+    // The default is "commented-out" but the example string must be "ulid".
+    assert.match(
+      config,
+      /\[id\][^\[]*strategy\s*=\s*"ulid"/s,
+      "default config should document strategy = \"ulid\" under [id]"
+    );
   });
 
   it("init does not create .gitignore for counter file", () => {
@@ -390,5 +396,115 @@ describe("CLI with ULID strategy", () => {
     assert.equal(result.exitCode, 0);
     assert.ok(result.stdout.includes("Searchable ULID"));
     assert.ok(!result.stdout.includes("Other task"));
+  });
+
+  it("purely-digit lookup does not silently match a ULID", () => {
+    // On a ULID-only vault, `vt done 01` must not return an arbitrary ULID
+    // whose ID happens to start with "01" — that's virtually every ULID from
+    // the current decade. It must report "No task matching" instead.
+    run(["new", "First ULID task"], dir);
+    const result = run(["done", "01"], dir);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /No task matching/);
+  });
+
+  it("--no-dedupe=true is correctly coerced to boolean", () => {
+    run(["new", "Duplicate me"], dir);
+    const result = run(["new", "Duplicate me", "--no-dedupe=true"], dir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(!result.stderr.includes("Similar tasks found"),
+      "--no-dedupe=true must suppress the warning");
+  });
+
+  it("--no-dedupe=garbage is rejected with actionable error", () => {
+    const result = run(["new", "X", "--no-dedupe=maybe"], dir);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /boolean|true\/false/i);
+  });
+
+  it("ambiguous prefix error tells user how to resolve it", () => {
+    // Force an ambiguous prefix by using a config with a prefix-rich
+    // identifier. Since our ULIDs share the same-ms prefix after
+    // monotonic seeding, create two quickly and lookup a very short prefix.
+    run(["new", "A"], dir);
+    run(["new", "B"], dir);
+    const result = run(["done", "0"], dir);
+    // "0" is purely-digit → numeric branch, not ULID prefix → "No task"
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /No task matching/);
+  });
+
+  it("list ignores non-task markdown files in backlog", () => {
+    run(["new", "Real task"], dir);
+    writeFileSync(join(dir, "backlog", "notes-about-x.md"), "# Random note\n");
+    const result = run(["list"], dir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes("Real task"));
+    assert.ok(!result.stdout.includes("Random note"));
+    assert.ok(!result.stdout.includes("notes-about-x"));
+  });
+});
+
+describe("CLI legacy sequential detection", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-cli-legacy-"));
+  });
+
+  it("no config + existing NNNN-*.md files → sequential default", () => {
+    // Simulate an existing 0.1.x vault that was upgraded to 0.2.0 without
+    // running `vt init`. The user has `backlog/0001-foo.md`; running `vt new`
+    // without a config must keep allocating sequential IDs, not start mixing
+    // ULIDs into the directory.
+    mkdirSync(join(dir, "backlog"), { recursive: true });
+    writeFileSync(
+      join(dir, "backlog", "0001-existing.md"),
+      "---\ntitle: existing\nstatus: open\npriority: medium\ntags: []\ncreated: 2026-01-01\nsource: \n---\n\n# existing\n"
+    );
+    const result = run(["new", "Second task"], dir);
+    assert.equal(result.exitCode, 0, `stderr: ${result.stderr}`);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md")).sort();
+    assert.equal(files.length, 2);
+    // Second file must be NNNN-prefixed, not a 26-char ULID
+    assert.match(files[1], /^0002-/);
+  });
+
+  it("no config + no existing files → ulid default", () => {
+    const result = run(["new", "First task"], dir);
+    assert.equal(result.exitCode, 0);
+    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md"));
+    assert.equal(files.length, 1);
+    assert.match(files[0], /^[0-9A-HJKMNP-TV-Z]{26}-/);
+  });
+});
+
+describe("CLI config validation", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-cli-badconf-"));
+  });
+
+  it("rejects invalid [id] strategy with actionable error", () => {
+    writeFileSync(
+      join(dir, ".vault-tasks.toml"),
+      '[id]\nstrategy = "uild"\n'
+    );
+    const result = run(["list"], dir);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /Invalid \[id\] strategy/);
+    assert.match(result.stderr, /sequential.*timestamp.*ulid/);
+  });
+
+  it("rejects dedupe_threshold out of range", () => {
+    writeFileSync(
+      join(dir, ".vault-tasks.toml"),
+      '[task]\ndedupe_threshold = 2\n'
+    );
+    const result = run(["list"], dir);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /dedupe_threshold/);
   });
 });

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -478,6 +478,55 @@ describe("CLI legacy sequential detection", () => {
     assert.equal(files.length, 1);
     assert.match(files[0], /^[0-9A-HJKMNP-TV-Z]{26}-/);
   });
+
+  it("config without explicit strategy + existing NNNN-*.md → sequential", () => {
+    // The real 0.1.x upgrade footgun: a user ran `vt init` on 0.1.x, so they
+    // have a config file, but the file leaves `[id] strategy` commented out.
+    // Existing numbered tasks must keep numbering — not silently switch to
+    // ULID just because the new default flipped.
+    mkdirSync(join(dir, "backlog"), { recursive: true });
+    writeFileSync(
+      join(dir, "backlog", "0042-existing.md"),
+      "---\ntitle: existing\nstatus: open\npriority: medium\ntags: []\ncreated: 2026-01-01\nsource: \n---\n\n# existing\n"
+    );
+    // Config present, but no [id] section / no strategy key.
+    writeFileSync(
+      join(dir, ".vault-tasks.toml"),
+      '[paths]\nbacklog_dir = "backlog"\narchive_dir = "archive"\n'
+    );
+
+    const result = run(["new", "Next task"], dir);
+    assert.equal(result.exitCode, 0, `stderr: ${result.stderr}`);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md")).sort();
+    assert.equal(files.length, 2);
+    assert.match(files[1], /^0043-/);
+  });
+
+  it("config with explicit strategy='ulid' + existing NNNN files → ulid (no override)", () => {
+    // The opposite case: the user has explicitly opted into ULID. We must
+    // respect that even though legacy NNNN files are present — the inference
+    // is only a fallback for unset strategy, not an override.
+    mkdirSync(join(dir, "backlog"), { recursive: true });
+    writeFileSync(
+      join(dir, "backlog", "0001-old.md"),
+      "---\ntitle: old\nstatus: open\npriority: medium\ntags: []\ncreated: 2026-01-01\nsource: \n---\n\n# old\n"
+    );
+    writeFileSync(
+      join(dir, ".vault-tasks.toml"),
+      '[paths]\nbacklog_dir = "backlog"\narchive_dir = "archive"\n\n[id]\nstrategy = "ulid"\n'
+    );
+
+    const result = run(["new", "New ulid"], dir);
+    assert.equal(result.exitCode, 0);
+    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md")).sort();
+    assert.equal(files.length, 2);
+    // New file must be a ULID, not 0002
+    assert.ok(
+      /^[0-9A-HJKMNP-TV-Z]{26}-/.test(files[0]) || /^[0-9A-HJKMNP-TV-Z]{26}-/.test(files[1]),
+      `Expected one ULID file in ${files.join(", ")}`
+    );
+  });
 });
 
 describe("CLI config validation", () => {

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -33,12 +33,22 @@ function run(args: string[], cwd: string): RunResult {
   }
 }
 
+/** Write a config file that forces sequential ID strategy for backwards-compat tests */
+function writeSequentialConfig(dir: string): void {
+  writeFileSync(
+    join(dir, ".vault-tasks.toml"),
+    '[paths]\nbacklog_dir = "backlog"\narchive_dir = "archive"\n\n[id]\nstrategy = "sequential"\npad_width = 4\n'
+  );
+}
+
 describe("CLI integration", () => {
   let dir: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "vt-cli-"));
     run(["init"], dir);
+    // Override to sequential for existing tests
+    writeSequentialConfig(dir);
   });
 
   it("init creates config and backlog dir", () => {
@@ -167,7 +177,7 @@ describe("CLI integration", () => {
     // Disable auto-archive so done tasks stay in backlog for manual archiving
     writeFileSync(
       join(dir, ".vault-tasks.toml"),
-      '[paths]\nbacklog_dir = "backlog"\narchive_dir = "archive"\n\n[task]\nauto_archive = false\n'
+      '[paths]\nbacklog_dir = "backlog"\narchive_dir = "archive"\n\n[task]\nauto_archive = false\n\n[id]\nstrategy = "sequential"\npad_width = 4\n'
     );
     run(["new", "Task A"], dir);
     run(["new", "Task B"], dir);
@@ -239,6 +249,7 @@ describe("CLI error handling", () => {
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "vt-cli-err-"));
     run(["init"], dir);
+    writeSequentialConfig(dir);
   });
 
   it("new without title fails with exit code 1", () => {
@@ -309,5 +320,75 @@ describe("CLI error handling", () => {
     const { meta } = parseFrontmatter(content);
     assert.equal(meta["status"], "in-progress");
     assert.equal(meta["priority"], "high");
+  });
+});
+
+describe("CLI with ULID strategy", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-cli-ulid-"));
+    run(["init"], dir);
+    // Default config is ULID — no override needed
+  });
+
+  it("init creates config with ulid as default", () => {
+    const config = readFileSync(join(dir, ".vault-tasks.toml"), "utf-8");
+    assert.ok(config.includes("ulid"));
+  });
+
+  it("init does not create .gitignore for counter file", () => {
+    // ULID strategy doesn't need a counter file
+    assert.ok(!existsSync(join(dir, ".gitignore")));
+  });
+
+  it("new creates task with ULID-prefixed filename", () => {
+    const result = run(["new", "ULID task", "--priority", "high"], dir);
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md"));
+    assert.equal(files.length, 1);
+    // ULID prefix: 26 uppercase Crockford base32 chars followed by a hyphen
+    assert.match(files[0], /^[0-9A-HJKMNP-TV-Z]{26}-ulid-task\.md$/);
+  });
+
+  it("show finds ULID task by prefix", () => {
+    run(["new", "Prefixed task"], dir);
+    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md"));
+    const ulidPrefix = files[0].slice(0, 8); // First 8 chars of ULID
+
+    const result = run(["show", ulidPrefix], dir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes("Prefixed task"));
+  });
+
+  it("done archives ULID task by prefix", () => {
+    run(["new", "Archive me"], dir);
+    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md"));
+    const ulidPrefix = files[0].slice(0, 10);
+
+    const result = run(["done", ulidPrefix], dir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes("archived"));
+
+    // Task should be in archive
+    const archiveFiles = readdirSync(join(dir, "backlog", "archive")).filter((f: string) => f.endsWith(".md"));
+    assert.equal(archiveFiles.length, 1);
+  });
+
+  it("list shows ULID tasks", () => {
+    run(["new", "Listed task"], dir);
+    const result = run(["list"], dir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes("Listed task"));
+  });
+
+  it("search finds ULID tasks", () => {
+    run(["new", "Searchable ULID"], dir);
+    run(["new", "Other task"], dir);
+    const result = run(["search", "searchable"], dir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes("Searchable ULID"));
+    assert.ok(!result.stdout.includes("Other task"));
   });
 });

--- a/src/tests/counter.test.ts
+++ b/src/tests/counter.test.ts
@@ -23,6 +23,8 @@ function makeConfig(dir: string, strategy: Config["idStrategy"] = "sequential"):
     idStrategy: strategy,
     padWidth: 4,
     slugMaxLength: 60,
+    dedupeThreshold: 0.5,
+    dedupeScanLimit: 500,
     project: { name: "", qualityCommand: "", testCommand: "", standardTags: [] },
   };
 }

--- a/src/tests/counter.test.ts
+++ b/src/tests/counter.test.ts
@@ -35,10 +35,13 @@ describe("getNextId", () => {
     mkdirSync(join(dir, "backlog"), { recursive: true });
   });
 
-  it("returns 1 for empty directory (sequential)", () => {
+  it("returns '1' for empty directory (sequential)", () => {
     const config = makeConfig(dir, "sequential");
     const id = getNextId(config);
-    assert.equal(id, 1);
+    assert.equal(typeof id, "string");
+    assert.equal(id, "1");
+    // formatId handles zero-padding
+    assert.equal(formatId(id, config), "0001");
   });
 
   it("returns max+1 when files exist (sequential)", () => {
@@ -46,7 +49,8 @@ describe("getNextId", () => {
     writeFileSync(join(dir, "backlog", "0003-task.md"), "");
     writeFileSync(join(dir, "backlog", "0001-task.md"), "");
     const id = getNextId(config);
-    assert.equal(id, 4);
+    assert.equal(id, "4");
+    assert.equal(formatId(id, config), "0004");
   });
 
   it("scans archive directory too (sequential)", () => {
@@ -55,7 +59,7 @@ describe("getNextId", () => {
     writeFileSync(join(dir, "backlog", "0001-task.md"), "");
     writeFileSync(join(dir, "backlog", "archive", "0005-old.md"), "");
     const id = getNextId(config);
-    assert.equal(id, 6);
+    assert.equal(id, "6");
   });
 
   it("ignores non-md files", () => {
@@ -63,27 +67,28 @@ describe("getNextId", () => {
     writeFileSync(join(dir, "backlog", "0010-readme.txt"), "");
     writeFileSync(join(dir, "backlog", "0002-task.md"), "");
     const id = getNextId(config);
-    assert.equal(id, 3);
+    assert.equal(id, "3");
   });
 
-  it("returns a numeric ID (timestamp strategy)", () => {
+  it("returns a 14-char string (timestamp strategy)", () => {
     const config = makeConfig(dir, "timestamp");
     const id = getNextId(config);
-    assert.equal(typeof id, "number");
-    assert.ok(id > 20000000000000, "timestamp ID should be 14 digits");
-    assert.ok(Number.isSafeInteger(id), "ID must be a safe integer");
+    assert.equal(typeof id, "string");
+    assert.equal(id.length, 14, "timestamp ID should be 14 digits");
+    assert.match(id, /^\d{14}$/);
   });
 
-  it("returns a numeric ID (ulid strategy)", () => {
+  it("returns a valid ULID string (ulid strategy)", () => {
     const config = makeConfig(dir, "ulid");
     const id = getNextId(config);
-    assert.equal(typeof id, "number");
-    assert.ok(Number.isSafeInteger(id), "ID must be a safe integer");
+    assert.equal(typeof id, "string");
+    assert.equal(id.length, 26, "ULID should be 26 characters");
+    assert.match(id, /^[0-9A-HJKMNP-TV-Z]{26}$/);
   });
 
   it("generates unique IDs on rapid calls (sequential)", () => {
     const config = makeConfig(dir, "sequential");
-    const ids = new Set<number>();
+    const ids = new Set<string>();
     for (let i = 0; i < 10; i++) {
       ids.add(getNextId(config));
       // Simulate a file being created with that ID
@@ -102,19 +107,19 @@ describe("formatId", () => {
 
   it("pads sequential IDs to padWidth", () => {
     const config = makeConfig(dir, "sequential");
-    assert.equal(formatId(1, config), "0001");
-    assert.equal(formatId(42, config), "0042");
-    assert.equal(formatId(12345, config), "12345");
+    assert.equal(formatId("1", config), "0001");
+    assert.equal(formatId("42", config), "0042");
+    assert.equal(formatId("12345", config), "12345");
   });
 
   it("does not pad timestamp IDs", () => {
     const config = makeConfig(dir, "timestamp");
-    assert.equal(formatId(20260331142300, config), "20260331142300");
+    assert.equal(formatId("20260331142300", config), "20260331142300");
   });
 
   it("does not pad ulid IDs", () => {
     const config = makeConfig(dir, "ulid");
-    const id = 1234567890123;
-    assert.equal(formatId(id, config), "1234567890123");
+    const id = "01HYX3KQPD7NG8RRGSSFQ9XNHY";
+    assert.equal(formatId(id, config), id);
   });
 });

--- a/src/tests/frontmatter.test.ts
+++ b/src/tests/frontmatter.test.ts
@@ -253,4 +253,25 @@ tags:
     const { meta: parsed } = parseFrontmatter(written);
     assert.deepEqual(parsed["sources"], ["[[note1]]", "[[note2]]"]);
   });
+
+  it("round-trips a ULID-shaped id string without numeric coercion", () => {
+    // ULIDs are all-uppercase Crockford base32; they must round-trip as a
+    // plain string, not be coerced to a number or YAML-quoted unnecessarily.
+    const ulid = "01HYXABCDEFGHJKMNPQRSTVWXY";
+    const { meta: parsed } = parseFrontmatter(
+      writeFrontmatter({ id: ulid, title: "t" }, "body")
+    );
+    assert.equal(parsed["id"], ulid);
+    assert.equal(typeof parsed["id"], "string");
+  });
+
+  it("round-trips a purely-numeric id string without becoming a number", () => {
+    // A numeric task ID like "42" must survive write/parse as a string so
+    // callers comparing `task.id === "42"` still succeed.
+    const { meta: parsed } = parseFrontmatter(
+      writeFrontmatter({ id: "42", title: "t" }, "body")
+    );
+    assert.equal(parsed["id"], "42");
+    assert.equal(typeof parsed["id"], "string");
+  });
 });

--- a/src/tests/output.test.ts
+++ b/src/tests/output.test.ts
@@ -5,7 +5,7 @@ import type { Task } from "../task.js";
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
-    id: 1,
+    id: "0001",
     title: "Test task",
     status: "open",
     priority: "medium",
@@ -70,7 +70,7 @@ describe("formatTaskTable", () => {
   });
 
   it("includes header, divider, and task rows", () => {
-    const tasks = [makeTask({ id: 1, title: "Test", status: "open", priority: "high" })];
+    const tasks = [makeTask({ id: "0001", title: "Test", status: "open", priority: "high" })];
     const result = formatTaskTable(tasks);
     const lines = result.split("\n");
     assert.ok(lines[0].includes("ID"));
@@ -92,7 +92,7 @@ describe("formatStaleTable", () => {
   });
 
   it("includes header and task rows", () => {
-    const items = [{ task: makeTask({ id: 42, title: "Old task" }), ageDays: 30 }];
+    const items = [{ task: makeTask({ id: "0042", title: "Old task" }), ageDays: 30 }];
     const result = formatStaleTable(items);
     assert.ok(result.includes("42"));
     assert.ok(result.includes("30"));

--- a/src/tests/similarity.test.ts
+++ b/src/tests/similarity.test.ts
@@ -65,4 +65,30 @@ describe("similarity", () => {
     );
     assert.ok(score > 0.6, `Expected > 0.6 for near-duplicate but got ${score}`);
   });
+
+  it("handles diacritics by folding them to base letters", () => {
+    // Previously "café" normalized to empty after stripping non-ASCII. Now
+    // NFKD folding drops the combining acute so "café" and "cafe" compare as
+    // identical words.
+    assert.equal(similarity("café résumé", "cafe resume"), 1.0);
+    const score = similarity("café résumé important", "Cafe Resume Important");
+    assert.equal(score, 1.0);
+  });
+
+  it("preserves non-ASCII letters instead of discarding them", () => {
+    // Two titles that share only the non-ASCII word must still have non-zero
+    // similarity. Under the old ASCII-only normalize() both normalized to "".
+    const score = similarity("über cool thing", "über not cool");
+    assert.ok(score > 0.3, `Expected > 0.3 with shared über/cool, got ${score}`);
+  });
+
+  it("handles pure-emoji titles without throwing", () => {
+    const score = similarity("🚀🚀🚀", "🎉🎉🎉");
+    assert.ok(score >= 0 && score <= 1, `Expected valid score, got ${score}`);
+  });
+
+  it("scores zero for one-empty-one-nonempty after normalization", () => {
+    // Title that normalizes to empty (pure punctuation) vs real content
+    assert.equal(similarity("!!!", "Real task"), 0.0);
+  });
 });

--- a/src/tests/similarity.test.ts
+++ b/src/tests/similarity.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { similarity } from "../similarity.js";
+
+describe("similarity", () => {
+  it("returns 1.0 for identical strings", () => {
+    assert.equal(similarity("Fix auth bug", "Fix auth bug"), 1.0);
+  });
+
+  it("returns 1.0 for strings that normalize to the same value", () => {
+    assert.equal(similarity("Fix Auth Bug!", "fix auth bug"), 1.0);
+  });
+
+  it("returns close to 0 for completely different strings", () => {
+    const score = similarity("Fix auth bug", "Deploy infrastructure");
+    assert.ok(score < 0.2, `Expected < 0.2 but got ${score}`);
+  });
+
+  it("scores high for word reordering", () => {
+    const score = similarity("Fix auth bug", "auth bug fix");
+    assert.ok(score > 0.7, `Expected > 0.7 for word reorder but got ${score}`);
+  });
+
+  it("scores high for similar titles with minor differences", () => {
+    const score = similarity(
+      "Fix login redirect bug",
+      "Fix the login redirect issue"
+    );
+    assert.ok(score > 0.5, `Expected > 0.5 for similar titles but got ${score}`);
+  });
+
+  it("handles empty strings", () => {
+    assert.equal(similarity("", ""), 1.0);
+    assert.equal(similarity("something", ""), 0.0);
+    assert.equal(similarity("", "something"), 0.0);
+  });
+
+  it("is case insensitive", () => {
+    const a = similarity("FIX AUTH BUG", "fix auth bug");
+    assert.equal(a, 1.0);
+  });
+
+  it("scores high despite punctuation differences", () => {
+    const score = similarity("fix: auth-bug!", "fix auth bug");
+    assert.ok(score > 0.7, `Expected > 0.7 despite punctuation but got ${score}`);
+  });
+
+  it("handles single-word titles", () => {
+    const score = similarity("auth", "authentication");
+    assert.ok(score > 0.3, `Expected > 0.3 for substring match but got ${score}`);
+  });
+
+  it("distinguishes clearly different tasks", () => {
+    const score = similarity(
+      "Add user authentication",
+      "Fix database migration"
+    );
+    assert.ok(score < 0.3, `Expected < 0.3 for different tasks but got ${score}`);
+  });
+
+  it("detects near-duplicate task titles", () => {
+    const score = similarity(
+      "vault-tasks should check filesystem for ID collisions",
+      "vt new should check filesystem for ID collisions before creating a task"
+    );
+    assert.ok(score > 0.6, `Expected > 0.6 for near-duplicate but got ${score}`);
+  });
+});

--- a/src/tests/store.test.ts
+++ b/src/tests/store.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Config } from "../config.js";
-import { TaskStore } from "../store.js";
+import { parseTaskIdFromFilename, TaskStore } from "../store.js";
 
 function makeConfig(dir: string): Config {
   return {
@@ -23,6 +23,8 @@ function makeConfig(dir: string): Config {
     idStrategy: "sequential",
     padWidth: 4,
     slugMaxLength: 60,
+    dedupeThreshold: 0.5,
+    dedupeScanLimit: 500,
     project: { name: "", qualityCommand: "", testCommand: "", standardTags: [] },
   };
 }
@@ -258,5 +260,103 @@ describe("TaskStore", () => {
     const reloaded = store.find("1");
     assert.equal(reloaded.status, "open");
     assert.equal(reloaded.extraMeta["custom_status"], "hacked");
+  });
+
+  it("ignores files with non-strict ID prefixes", () => {
+    store.create({ title: "Real task" });
+    // Filenames that look "task-like" but don't match strict ID formats
+    // (alphanumeric prefix but not a canonical ULID or a numeric ID) must be
+    // filtered out of listing, lookup, and dedupe.
+    mkdirSync(join(dir, "backlog"), { recursive: true });
+    writeFileSync(join(dir, "backlog", "notes-about-x.md"), "# notes\n");
+    writeFileSync(join(dir, "backlog", "README.md"), "# readme\n");
+    // ULID with illegal char (L) — should be rejected
+    writeFileSync(
+      join(dir, "backlog", "01ARZ3NDLKTSV4RRGSSFQ9XNHY-bad.md"),
+      "---\ntitle: bad\n---\n"
+    );
+
+    const tasks = store.loadAll();
+    assert.equal(tasks.length, 1);
+    assert.equal(tasks[0].title, "Real task");
+
+    // find() must not surface any of the non-task files by substring either
+    assert.throws(() => store.find("notes"), /No task matching/);
+    assert.throws(() => store.find("README"), /No task matching/);
+  });
+
+  it("ambiguous-match error includes next-step guidance", () => {
+    store.create({ title: "Fix login" });
+    store.create({ title: "Fix login page" });
+    try {
+      store.find("login");
+      assert.fail("expected an error");
+    } catch (err) {
+      const msg = (err as Error).message;
+      assert.match(msg, /Ambiguous match/);
+      assert.match(msg, /more characters|full filename/i);
+    }
+  });
+
+  it("loadRecent caps results at limit, preferring newest", () => {
+    for (let i = 0; i < 10; i++) {
+      store.create({ title: `Task ${i}` });
+    }
+    const recent = store.loadRecent(3);
+    assert.equal(recent.length, 3);
+    // Sequential IDs: 0008, 0009, 0010 are newest
+    assert.deepEqual(
+      recent.map((t) => t.id).sort(),
+      ["0008", "0009", "0010"]
+    );
+  });
+
+  it("loadRecent with limit=0 returns all tasks", () => {
+    store.create({ title: "A" });
+    store.create({ title: "B" });
+    const all = store.loadRecent(0);
+    assert.equal(all.length, 2);
+  });
+});
+
+describe("parseTaskIdFromFilename", () => {
+  it("accepts canonical ULID filenames", () => {
+    assert.equal(
+      parseTaskIdFromFilename("01HYXABCDEFGHJKMNPQRSTVWXY-title.md"),
+      "01HYXABCDEFGHJKMNPQRSTVWXY"
+    );
+  });
+
+  it("accepts sequential filenames", () => {
+    assert.equal(parseTaskIdFromFilename("0001-title.md"), "0001");
+    assert.equal(parseTaskIdFromFilename("42-title.md"), "42");
+  });
+
+  it("accepts 14-digit timestamp filenames", () => {
+    assert.equal(
+      parseTaskIdFromFilename("20260413120000-title.md"),
+      "20260413120000"
+    );
+  });
+
+  it("rejects ULIDs containing excluded chars (I/L/O/U)", () => {
+    // 26 chars but includes forbidden letters — must be rejected to keep
+    // lookup/list behavior consistent with the ULID generator's strictness.
+    assert.equal(
+      parseTaskIdFromFilename("01ARZ3NDLKTSV4RRGSSFQ9XNHY-x.md"),
+      null
+    );
+  });
+
+  it("rejects non-task markdown filenames", () => {
+    assert.equal(parseTaskIdFromFilename("notes-about-x.md"), null);
+    assert.equal(parseTaskIdFromFilename("README.md"), null);
+    assert.equal(parseTaskIdFromFilename("abc-def.md"), null);
+    assert.equal(parseTaskIdFromFilename(".hidden.md"), null);
+  });
+
+  it("rejects non-.md files", () => {
+    assert.equal(parseTaskIdFromFilename("0001-title.txt"), null);
+    assert.equal(parseTaskIdFromFilename("0001-title"), null);
   });
 });

--- a/src/tests/store.test.ts
+++ b/src/tests/store.test.ts
@@ -38,7 +38,7 @@ describe("TaskStore", () => {
 
   it("creates a task", () => {
     const task = store.create({ title: "Test task" });
-    assert.equal(task.id, 1);
+    assert.equal(task.id, "0001");
     assert.equal(task.title, "Test task");
     assert.equal(task.status, "open");
     assert.equal(task.priority, "medium");
@@ -48,8 +48,8 @@ describe("TaskStore", () => {
   it("creates tasks with incrementing IDs", () => {
     const t1 = store.create({ title: "First" });
     const t2 = store.create({ title: "Second" });
-    assert.equal(t1.id, 1);
-    assert.equal(t2.id, 2);
+    assert.equal(t1.id, "0001");
+    assert.equal(t2.id, "0002");
   });
 
   it("loads all tasks", () => {

--- a/src/tests/ulid.test.ts
+++ b/src/tests/ulid.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  generateUlid,
+  isValidUlid,
+  decodeTime,
+  _resetMonotonicState,
+} from "../ulid.js";
+
+describe("generateUlid", () => {
+  beforeEach(() => {
+    _resetMonotonicState();
+  });
+
+  it("returns a 26-character string", () => {
+    const ulid = generateUlid();
+    assert.equal(ulid.length, 26);
+  });
+
+  it("contains only valid Crockford base32 characters", () => {
+    const ulid = generateUlid();
+    assert.match(ulid, /^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it("does not contain excluded characters I, L, O, U", () => {
+    // Generate many ULIDs to increase coverage of alphabet
+    for (let i = 0; i < 100; i++) {
+      const ulid = generateUlid();
+      assert.ok(!ulid.includes("I"), `ULID contains I: ${ulid}`);
+      assert.ok(!ulid.includes("L"), `ULID contains L: ${ulid}`);
+      assert.ok(!ulid.includes("O"), `ULID contains O: ${ulid}`);
+      assert.ok(!ulid.includes("U"), `ULID contains U: ${ulid}`);
+    }
+  });
+
+  it("generates monotonically increasing values", () => {
+    const ulids: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      ulids.push(generateUlid());
+    }
+    for (let i = 1; i < ulids.length; i++) {
+      assert.ok(
+        ulids[i] > ulids[i - 1],
+        `ULID ${i} (${ulids[i]}) should be > ULID ${i - 1} (${ulids[i - 1]})`
+      );
+    }
+  });
+
+  it("produces unique values across rapid calls", () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      set.add(generateUlid());
+    }
+    assert.equal(set.size, 1000, "All 1000 ULIDs should be unique");
+  });
+
+  it("encodes a valid timestamp in the first 10 characters", () => {
+    const before = Date.now();
+    const ulid = generateUlid();
+    const after = Date.now();
+    const decoded = decodeTime(ulid);
+    assert.ok(decoded >= before, `Decoded time ${decoded} should be >= ${before}`);
+    assert.ok(decoded <= after, `Decoded time ${decoded} should be <= ${after}`);
+  });
+});
+
+describe("isValidUlid", () => {
+  it("accepts a valid ULID", () => {
+    const ulid = generateUlid();
+    assert.ok(isValidUlid(ulid));
+  });
+
+  it("accepts lowercase input", () => {
+    const ulid = generateUlid();
+    assert.ok(isValidUlid(ulid.toLowerCase()));
+  });
+
+  it("rejects strings that are too short", () => {
+    assert.ok(!isValidUlid("01ARZ3NDEKTSV4RR"));
+  });
+
+  it("rejects strings that are too long", () => {
+    assert.ok(!isValidUlid("01ARZ3NDEKTSV4RRGSSFQ9XNHY0X"));
+  });
+
+  it("rejects strings with excluded characters", () => {
+    // I, L, O, U are excluded from Crockford base32
+    assert.ok(!isValidUlid("01ARZ3NDIKTSV4RRGSSFQ9XNHY")); // I at position 7
+    assert.ok(!isValidUlid("01ARZ3NDLKTSV4RRGSSFQ9XNHY")); // L at position 7
+    assert.ok(!isValidUlid("01ARZ3NDOKTSV4RRGSSFQ9XNHY")); // O at position 7
+    assert.ok(!isValidUlid("01ARZ3NDUKTSV4RRGSSFQ9XNHY")); // U at position 7
+  });
+
+  it("rejects empty string", () => {
+    assert.ok(!isValidUlid(""));
+  });
+
+  it("rejects non-alphanumeric characters", () => {
+    assert.ok(!isValidUlid("01ARZ3NDEKTSV4RR-SSFQ9XNHY"));
+  });
+});
+
+describe("decodeTime", () => {
+  it("round-trips a known timestamp", () => {
+    const now = Date.now();
+    const ulid = generateUlid();
+    const decoded = decodeTime(ulid);
+    // Should be within 1ms of now
+    assert.ok(Math.abs(decoded - now) <= 1);
+  });
+
+  it("throws on invalid length", () => {
+    assert.throws(() => decodeTime("short"), /expected 26 characters/);
+  });
+
+  it("throws on invalid characters", () => {
+    assert.throws(
+      () => decodeTime("!LARZ3NDEKTSV4RRGSSFQ9XNHY"),
+      /Invalid ULID character/
+    );
+  });
+});

--- a/src/tests/ulid.test.ts
+++ b/src/tests/ulid.test.ts
@@ -115,8 +115,76 @@ describe("decodeTime", () => {
 
   it("throws on invalid characters", () => {
     assert.throws(
-      () => decodeTime("!LARZ3NDEKTSV4RRGSSFQ9XNHY"),
+      () => decodeTime("!1ARZ3NDEKTSV4RRGSSFQ9XNHY"),
       /Invalid ULID character/
     );
+  });
+
+  it("rejects Crockford ambiguity characters I/L/O (canonical-strict)", () => {
+    // We're the sole ULID producer, so a ULID arriving with one of these
+    // letters is either corrupted or hand-edited. Match isValidUlid's
+    // strictness instead of silently translating I→1 / L→1 / O→0.
+    assert.throws(
+      () => decodeTime("01ARZ3NDLKTSV4RRGSSFQ9XNHY"),
+      /Invalid ULID character/
+    );
+    assert.throws(
+      () => decodeTime("01ARZ3NDIKTSV4RRGSSFQ9XNHY"),
+      /Invalid ULID character/
+    );
+    assert.throws(
+      () => decodeTime("01ARZ3NDOKTSV4RRGSSFQ9XNHY"),
+      /Invalid ULID character/
+    );
+  });
+});
+
+describe("monotonic overflow", () => {
+  it("does not throw when the 80-bit random space is exhausted", () => {
+    _resetMonotonicState();
+    // Pin a deterministic clock and seed the random portion near overflow so
+    // incrementRandom rolls over. generateUlid must recover by bumping to the
+    // next ms and reseeding rather than throwing.
+    const originalNow = Date.now;
+    try {
+      const fixedMs = 1700000000000;
+      Date.now = () => fixedMs;
+      // Prime monotonic state
+      const first = generateUlid();
+      assert.equal(decodeTime(first), fixedMs);
+
+      // Force a pathological case by repeatedly calling generateUlid; we can't
+      // cheaply exhaust 80 bits, but we can verify many same-ms calls succeed
+      // and remain strictly increasing (no throw, no duplicate).
+      const prev = new Set<string>([first]);
+      let last = first;
+      for (let i = 0; i < 1000; i++) {
+        const u = generateUlid();
+        assert.ok(u > last, `ULID ${i} not increasing: ${last} → ${u}`);
+        assert.ok(!prev.has(u), `duplicate ULID at iteration ${i}: ${u}`);
+        prev.add(u);
+        last = u;
+      }
+    } finally {
+      Date.now = originalNow;
+      _resetMonotonicState();
+    }
+  });
+
+  it("never regresses when the clock steps backwards", () => {
+    _resetMonotonicState();
+    const originalNow = Date.now;
+    try {
+      let t = 1700000000000;
+      Date.now = () => t;
+      const a = generateUlid();
+      // Clock jumps backwards by 1s (e.g., NTP step)
+      t -= 1000;
+      const b = generateUlid();
+      assert.ok(b > a, `ULID must not regress on clock rewind: ${a} → ${b}`);
+    } finally {
+      Date.now = originalNow;
+      _resetMonotonicState();
+    }
   });
 });

--- a/src/ulid.ts
+++ b/src/ulid.ts
@@ -14,19 +14,16 @@ import { randomBytes } from "node:crypto";
 const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 const ENCODING_LEN = ENCODING.length; // 32
 
-// Crockford base32 decoding table (case-insensitive, handles I→1, L→1, O→0)
+// Canonical Crockford base32 decoding table. We reject I, L, O (and U) as
+// invalid rather than translating them: since this module is the sole producer
+// of ULIDs in the vault, any ULID we encounter that contains those letters is
+// either corrupted or hand-edited — treating it as "probably 0/1" silently
+// papers over a real problem. Stay strict and fail loudly.
 const DECODE: Record<string, number> = {};
 for (let i = 0; i < ENCODING.length; i++) {
   DECODE[ENCODING[i]] = i;
   DECODE[ENCODING[i].toLowerCase()] = i;
 }
-// Crockford spec: I/i→1, L/l→1, O/o→0
-DECODE["I"] = 1;
-DECODE["i"] = 1;
-DECODE["L"] = 1;
-DECODE["l"] = 1;
-DECODE["O"] = 0;
-DECODE["o"] = 0;
 
 // Monotonic state
 let lastTime = 0;
@@ -56,7 +53,7 @@ function encodeRandom(len: number): number[] {
   return chars;
 }
 
-function incrementRandom(random: number[]): number[] {
+function incrementRandom(random: number[]): number[] | null {
   const next = [...random];
   for (let i = next.length - 1; i >= 0; i--) {
     if (next[i] < ENCODING_LEN - 1) {
@@ -65,8 +62,9 @@ function incrementRandom(random: number[]): number[] {
     }
     next[i] = 0;
   }
-  // Overflow — all 80 bits were maxed. Astronomically unlikely.
-  throw new Error("ULID random overflow: cannot increment within same millisecond");
+  // All 80 random bits maxed — astronomically unlikely, but signal overflow
+  // to the caller instead of throwing, so it can bump lastTime by 1 ms.
+  return null;
 }
 
 function randomCharsToString(chars: number[]): string {
@@ -78,15 +76,24 @@ function randomCharsToString(chars: number[]): string {
  */
 export function generateUlid(): string {
   const now = Date.now();
+  // Guard against clock skew (NTP step backwards): never let lastTime regress.
+  const effective = now > lastTime ? now : lastTime;
 
-  if (now === lastTime) {
-    lastRandom = incrementRandom(lastRandom);
+  if (effective === lastTime) {
+    const incremented = incrementRandom(lastRandom);
+    if (incremented === null) {
+      // 80-bit space exhausted in a single ms — bump to the next ms and reseed.
+      lastTime = effective + 1;
+      lastRandom = encodeRandom(16);
+    } else {
+      lastRandom = incremented;
+    }
   } else {
-    lastTime = now;
+    lastTime = effective;
     lastRandom = encodeRandom(16);
   }
 
-  return encodeTime(now, 10) + randomCharsToString(lastRandom);
+  return encodeTime(lastTime, 10) + randomCharsToString(lastRandom);
 }
 
 const VALID_ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;

--- a/src/ulid.ts
+++ b/src/ulid.ts
@@ -1,0 +1,131 @@
+import { randomBytes } from "node:crypto";
+
+/**
+ * Zero-dependency ULID generator implementing the ULID spec.
+ * https://github.com/ulid/spec
+ *
+ * Format: 26-character Crockford base32 string
+ *   - 10 chars: millisecond timestamp (48 bits)
+ *   - 16 chars: cryptographic randomness (80 bits)
+ *
+ * Monotonic: same-millisecond calls increment the random portion.
+ */
+
+const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const ENCODING_LEN = ENCODING.length; // 32
+
+// Crockford base32 decoding table (case-insensitive, handles I→1, L→1, O→0)
+const DECODE: Record<string, number> = {};
+for (let i = 0; i < ENCODING.length; i++) {
+  DECODE[ENCODING[i]] = i;
+  DECODE[ENCODING[i].toLowerCase()] = i;
+}
+// Crockford spec: I/i→1, L/l→1, O/o→0
+DECODE["I"] = 1;
+DECODE["i"] = 1;
+DECODE["L"] = 1;
+DECODE["l"] = 1;
+DECODE["O"] = 0;
+DECODE["o"] = 0;
+
+// Monotonic state
+let lastTime = 0;
+let lastRandom: number[] = new Array(16).fill(0);
+
+function encodeTime(now: number, len: number): string {
+  let mod: number;
+  let remaining = now;
+  const chars: string[] = new Array(len);
+
+  for (let i = len - 1; i >= 0; i--) {
+    mod = remaining % ENCODING_LEN;
+    chars[i] = ENCODING[mod];
+    remaining = (remaining - mod) / ENCODING_LEN;
+  }
+
+  return chars.join("");
+}
+
+function encodeRandom(len: number): number[] {
+  const bytes = randomBytes(len);
+  const chars: number[] = new Array(len);
+  for (let i = 0; i < len; i++) {
+    // No modulo bias: 256 % 32 === 0, so all values 0-31 are equally likely
+    chars[i] = bytes[i] % ENCODING_LEN;
+  }
+  return chars;
+}
+
+function incrementRandom(random: number[]): number[] {
+  const next = [...random];
+  for (let i = next.length - 1; i >= 0; i--) {
+    if (next[i] < ENCODING_LEN - 1) {
+      next[i]++;
+      return next;
+    }
+    next[i] = 0;
+  }
+  // Overflow — all 80 bits were maxed. Astronomically unlikely.
+  throw new Error("ULID random overflow: cannot increment within same millisecond");
+}
+
+function randomCharsToString(chars: number[]): string {
+  return chars.map((c) => ENCODING[c]).join("");
+}
+
+/**
+ * Generate a ULID string. Monotonic within the same millisecond.
+ */
+export function generateUlid(): string {
+  const now = Date.now();
+
+  if (now === lastTime) {
+    lastRandom = incrementRandom(lastRandom);
+  } else {
+    lastTime = now;
+    lastRandom = encodeRandom(16);
+  }
+
+  return encodeTime(now, 10) + randomCharsToString(lastRandom);
+}
+
+const VALID_ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+/**
+ * Validate that a string is a well-formed ULID.
+ * Checks length (26) and that all characters are in the Crockford base32 alphabet.
+ */
+export function isValidUlid(s: string): boolean {
+  return VALID_ULID_RE.test(s.toUpperCase());
+}
+
+/**
+ * Extract the millisecond timestamp from a ULID string.
+ * Returns the Unix epoch milliseconds encoded in the first 10 characters.
+ */
+export function decodeTime(ulid: string): number {
+  if (ulid.length !== 26) {
+    throw new Error(`Invalid ULID: expected 26 characters, got ${ulid.length}`);
+  }
+
+  const timeChars = ulid.slice(0, 10).toUpperCase();
+  let time = 0;
+
+  for (const char of timeChars) {
+    const val = DECODE[char];
+    if (val === undefined) {
+      throw new Error(`Invalid ULID character: ${char}`);
+    }
+    time = time * ENCODING_LEN + val;
+  }
+
+  return time;
+}
+
+/**
+ * Reset monotonic state. Only for testing.
+ */
+export function _resetMonotonicState(): void {
+  lastTime = 0;
+  lastRandom = new Array(16).fill(0);
+}

--- a/templates/rules/backlog.md
+++ b/templates/rules/backlog.md
@@ -4,7 +4,7 @@ globs: {{backlog_dir}}/**
 
 # Backlog Rules
 
-- One task per file in `{{backlog_dir}}/`, named `NNNN-kebab-case-title.md`
+- One task per file in `{{backlog_dir}}/`, named `<id>-kebab-case-title.md` (ULID by default, or `NNNN` for sequential)
 - Required frontmatter: `title`, `status`, `priority`, `tags`, `created`, `source`
 - Status values: `open`, `in-progress`, `done`, `wont-do`
 - Priority values: `high`, `medium`, `low`

--- a/templates/skills/task/SKILL.md
+++ b/templates/skills/task/SKILL.md
@@ -24,5 +24,5 @@ description: Create, list, or manage backlog tasks. Use when the user says "add 
 - When noticing something off-scope during a session, default to `priority: medium`, `status: open`
 - Always set `source` to link back to where the task was noticed
 - Prefer creating tasks over mental bookmarks — the backlog is cheap
-- The CLI supports both numeric ID lookup (`vt done 1`) and substring matching (`vt done lateral`)
+- The CLI supports ULID prefix lookup (`vt done 01HYX`), numeric ID lookup (`vt done 1`), and substring matching (`vt done lateral`)
 - Check `.vault-tasks.toml` `[project.tags]` for standard tags to use


### PR DESCRIPTION
## Summary

- **ULID is now the default ID strategy** — collision-proof (timestamp + 80-bit random), no counter file needed, lexicographically sortable
- **`Task.id` changed from `number` to `string`** — uniform handling across all strategies (BREAKING)
- **Fuzzy duplicate detection** on `vt new` — trigram Dice similarity warns when similar tasks exist (suppress with `--no-dedupe`)
- **ULID prefix matching** — `vt done 01HYX` matches by ID prefix, alongside existing numeric and substring lookup
- **Sequential IDs remain fully supported** — set `strategy = "sequential"` in `.vault-tasks.toml`

## Breaking changes

- `Task.id` type: `number` → `string` (affects library API consumers)
- Default ID strategy: `sequential` → `ulid` (new vaults get ULID; existing vaults with explicit config are unaffected)
- Version bump: `0.1.0` → `0.2.0`

## New files

| File | Purpose |
|------|---------|
| `src/ulid.ts` | Zero-dependency ULID generator (Crockford base32, monotonic) |
| `src/similarity.ts` | Trigram Dice coefficient for title similarity |
| `src/tests/ulid.test.ts` | 16 tests for ULID generation and validation |
| `src/tests/similarity.test.ts` | 11 tests for similarity scoring |

## Test plan

- [x] 190 tests passing (was 156), zero failures
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] End-to-end smoke test: `vt init` → `vt new` (ULID filenames) → duplicate warning → prefix match → archive
- [x] Backwards compat: existing sequential CLI tests pass with explicit `strategy = "sequential"` config
- [x] Code review: double-padding bug fixed, `--no-dedupe` in help text, modulo bias documented

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)