### PR TITLE
feat: add vt lint command and skill template (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented here.
 
+## 0.3.0
+
+### Added
+
+- **`vt lint`** — read-only audit of an Obsidian-style vault. Detects
+  broken wikilinks (with frequency aggregation and "did you mean?"
+  suggestions), orphan evergreens, stale references, and convention drift
+  on evergreens. Completes the Maintain pillar of the LLM-Wiki pattern
+  alongside `vt new` (Compile) and `vt stale`/`vt archive`.
+
+  Resolution is Obsidian-correct: case-insensitive,
+  whitespace/hyphen/underscore/colon-agnostic, resolves against filename
+  stem, full path, `title:` frontmatter, and `aliases:`. Path-form
+  (`[[10-areas/foo/CONTEXT]]`) and partial-tail (`[[parenting/CONTEXT]]`)
+  targets work. `|alias` and `#anchor` suffixes are stripped before
+  resolution.
+
+  CLI flags: `--only <check>`, `--scope <dir>`, `--json`, `--quiet`,
+  `--no-suggestions`. Exit codes: `0` clean, `1` issues, `2` config/I-O
+  error.
+
+  Per-file opt-outs via flat frontmatter keys: `lint_orphan_ok`,
+  `lint_stale_ok`, `lint_drift_ok`.
+
+  Configurable in `.vault-tasks.toml` under `[lint]` and
+  `[lint.evergreen_conventions]`.
+
+- **`/lint` skill template** installed by `vt install-skills --install`.
+  Wraps the CLI for a Claude Code conversation: presents findings,
+  suggests next actions, never auto-edits.
+
+- Library API: `lintVault`, `buildIndex`, `resolveTarget`,
+  `collectWikilinks`, `findBrokenLinks`, `findOrphanEvergreens`,
+  `findStaleReferences`, `findEvergreenDrift`, `attachSuggestions`,
+  `computeLeverageFixes`, plus the `LintReport` / `LintOptions` /
+  `WikiLink` / `VaultFile` types.
+
 ## 0.2.0
 
 ### Breaking — library API

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ vt done 1
 | `vt stale` | List open tasks older than 14 days. `--days` to customize |
 | `vt archive` | Move all completed tasks to the archive directory |
 | `vt tags` | List all tags and their counts |
+| `vt lint` | Audit the vault: broken wikilinks, orphan evergreens, stale refs, drift. `--only`, `--scope`, `--json`, `--quiet`, `--no-suggestions` |
 | `vt init` | Initialize config and backlog directory |
 | `vt install-skills` | Install Claude Code skills and rules. `--install`, `--list`, `--update` |
 
@@ -132,6 +133,7 @@ This installs into `.claude/skills/` and `.claude/rules/`:
 | `/build-log` | End-of-session log: what was built, learned, decided. Extracts tasks |
 | `/weekly-review` | Consolidates journal entries, creates evergreen notes, triages backlog |
 | `/task` | Quick task creation/management from within a session |
+| `/lint` | Vault health check: broken wikilinks, orphans, stale refs, convention drift |
 
 Skills reference configurable vault paths (`journal_dir`, `projects_dir`, `evergreen_dir`) which are substituted from your `.vault-tasks.toml` at install time. Customize any skill by creating a `SKILL.local.md` next to the installed `SKILL.md` -- local files are never overwritten.
 
@@ -167,7 +169,12 @@ store.archiveCompleted();
 - `loadConfig` / `findConfigFile` -- config discovery and parsing
 - `parseFrontmatter` / `writeFrontmatter` -- YAML frontmatter utilities
 - `slugify` -- title to kebab-case filename
-- Types: `Task`, `CreateTaskOpts`, `Config`
+- `lintVault` -- run all lint checks; returns a `LintReport`
+- Lower-level lint primitives: `buildIndex`, `resolveTarget`,
+  `collectWikilinks`, `findBrokenLinks`, `findOrphanEvergreens`,
+  `findStaleReferences`, `findEvergreenDrift`, `attachSuggestions`
+- Types: `Task`, `CreateTaskOpts`, `Config`, `LintReport`, `LintOptions`,
+  `WikiLink`, `VaultFile`, `BrokenEntry`, `Suggestion`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-tasks",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Markdown-file task manager for solo devs building with Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { cmdDone } from "./commands/done.js";
 import { cmdEdit } from "./commands/edit.js";
 import { cmdInit } from "./commands/init.js";
 import { cmdInstallSkills } from "./commands/install-skills.js";
+import { cmdLint } from "./commands/lint.js";
 import { cmdList } from "./commands/list.js";
 import { cmdNew } from "./commands/new.js";
 import { cmdSearch } from "./commands/search.js";
@@ -29,6 +30,7 @@ Commands:
   edit <id>             Edit task fields (--status, --priority, --tags)
   archive               Move completed tasks to archive
   tags                  List all tags in use
+  lint                  Audit the vault for broken wikilinks, orphans, stale refs, drift
   init                  Initialize vault-tasks in current directory
   install-skills        Install Claude Code skills and rules
 
@@ -45,10 +47,26 @@ Options (vary by command):
   --days, -d            Stale threshold in days (default: 14)
   --list                List available skills
   --update              Overwrite existing skill files
+  --only                Run a single lint check (broken|orphans|stale|drift)
+  --scope               Restrict lint to files under <dir>
+  --json                Machine-readable lint output
+  --quiet               Print only the lint SUMMARY line
+  --no-suggestions      Skip "did you mean?" suggestions in lint
   --help, -h            Show this help message
 `;
 
-const BOOLEAN_FLAGS = new Set(["all", "commit", "install", "list", "update", "help", "no-dedupe"]);
+const BOOLEAN_FLAGS = new Set([
+  "all",
+  "commit",
+  "install",
+  "list",
+  "update",
+  "help",
+  "no-dedupe",
+  "json",
+  "quiet",
+  "no-suggestions",
+]);
 
 function isFlag(arg: string): boolean {
   if (arg.startsWith("--")) return true;
@@ -280,6 +298,16 @@ function main(): void {
 
       case "tags":
         cmdTags(config);
+        break;
+
+      case "lint":
+        cmdLint(config, {
+          only: args["only"] as string | undefined,
+          scope: args["scope"] as string | undefined,
+          json: args["json"] === true,
+          quiet: args["quiet"] === true,
+          noSuggestions: args["no-suggestions"] === true,
+        });
         break;
 
       default:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -300,15 +300,32 @@ function main(): void {
         cmdTags(config);
         break;
 
-      case "lint":
+      case "lint": {
+        // --only and --scope are value-bearing flags. parseArgs sets them to
+        // `true` if the user passes the flag without a value (e.g. `--only`
+        // followed by another flag or end-of-args), so coerce explicitly
+        // rather than asserting the type away.
+        const onlyArg = args["only"];
+        const scopeArg = args["scope"];
+        if (onlyArg === true) {
+          console.error("Error: --only requires a value (broken|orphans|stale|drift)");
+          process.exitCode = 2;
+          return;
+        }
+        if (scopeArg === true) {
+          console.error("Error: --scope requires a value (a directory)");
+          process.exitCode = 2;
+          return;
+        }
         cmdLint(config, {
-          only: args["only"] as string | undefined,
-          scope: args["scope"] as string | undefined,
+          only: typeof onlyArg === "string" ? onlyArg : undefined,
+          scope: typeof scopeArg === "string" ? scopeArg : undefined,
           json: args["json"] === true,
           quiet: args["quiet"] === true,
           noSuggestions: args["no-suggestions"] === true,
         });
         break;
+      }
 
       default:
         console.error(`Unknown command: ${command}\n`);

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,0 +1,63 @@
+import type { Config } from "../config.js";
+import { lintVault } from "../lint/index.js";
+import {
+  formatHumanReport,
+  formatJsonReport,
+  formatSummaryLine,
+} from "../lint/report.js";
+import type { CheckName } from "../lint/types.js";
+
+const VALID_CHECKS: ReadonlySet<CheckName> = new Set(["broken", "orphans", "stale", "drift"]);
+
+interface LintCmdArgs {
+  only?: string;
+  scope?: string;
+  json?: boolean;
+  quiet?: boolean;
+  noSuggestions?: boolean;
+}
+
+export function cmdLint(config: Config, args: LintCmdArgs): void {
+  let only: CheckName | undefined;
+  if (args.only !== undefined) {
+    const v = args.only.toLowerCase();
+    if (!VALID_CHECKS.has(v as CheckName)) {
+      console.error(
+        `Error: --only must be one of broken|orphans|stale|drift (got '${args.only}')`
+      );
+      process.exitCode = 2;
+      return;
+    }
+    only = v as CheckName;
+  }
+
+  if (args.scope !== undefined && args.scope.includes("..")) {
+    console.error("Error: --scope must be inside the vault (no '..')");
+    process.exitCode = 2;
+    return;
+  }
+
+  let report;
+  try {
+    report = lintVault(config, {
+      only,
+      scope: args.scope,
+      noSuggestions: args.noSuggestions === true,
+      onWarn: (msg) => console.error(`WARN: ${msg}`),
+    });
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (args.quiet === true) {
+    console.log(formatSummaryLine(report));
+  } else if (args.json === true) {
+    console.log(formatJsonReport(report));
+  } else {
+    console.log(formatHumanReport(report));
+  }
+
+  process.exitCode = report.hasIssues ? 1 : 0;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,25 @@ import { dirname, join, relative, resolve } from "node:path";
 export const ID_STRATEGIES = ["sequential", "timestamp", "ulid"] as const;
 export type IdStrategy = (typeof ID_STRATEGIES)[number];
 
+export interface LintEvergreenConventions {
+  requireFrontmatter: boolean;
+  requireTitleField: boolean;
+  requireTagsField: boolean;
+  requireRelatedSection: boolean;
+  requireBodyWikilink: boolean;
+}
+
+export interface LintConfig {
+  referenceDir: string;
+  referenceExclude: string[];
+  templateSourceDirs: string[];
+  templateSourceFiles: string[];
+  templatePatterns: string[];
+  skipDirs: string[];
+  evergreenConventions: LintEvergreenConventions;
+  suggestionThreshold: number;
+}
+
 export interface Config {
   vaultRoot: string;
   backlogDir: string;
@@ -28,7 +47,39 @@ export interface Config {
     testCommand: string;
     standardTags: string[];
   };
+  lint: LintConfig;
 }
+
+export const DEFAULT_LINT_TEMPLATE_PATTERNS: readonly string[] = [
+  "^YYYY",
+  "^<",
+  "^wikilinks?$",
+  "^target$",
+  "^note-name$",
+  "^build-log-title$",
+  "^filename",
+  "^\\d{4}-task-slug$",
+  "^Evergreen note title$",
+  "^0001-task-slug$",
+  "^0003-old-task$",
+];
+
+const DEFAULT_LINT: LintConfig = {
+  referenceDir: "references",
+  referenceExclude: ["tweets/"],
+  templateSourceDirs: [".claude/skills/", ".claude/rules/"],
+  templateSourceFiles: ["CLAUDE.md"],
+  templatePatterns: [...DEFAULT_LINT_TEMPLATE_PATTERNS],
+  skipDirs: [".obsidian", "node_modules", ".git", "dist", "build"],
+  evergreenConventions: {
+    requireFrontmatter: true,
+    requireTitleField: true,
+    requireTagsField: true,
+    requireRelatedSection: true,
+    requireBodyWikilink: true,
+  },
+  suggestionThreshold: 0.6,
+};
 
 const DEFAULTS: Config = {
   vaultRoot: process.cwd(),
@@ -54,6 +105,7 @@ const DEFAULTS: Config = {
     testCommand: "",
     standardTags: [],
   },
+  lint: DEFAULT_LINT,
 };
 
 const CONFIG_FILENAME = ".vault-tasks.toml";
@@ -225,6 +277,7 @@ export function loadConfig(startDir?: string): Config {
       evergreenDir: resolve(vaultRoot, DEFAULTS.evergreenDir),
       idStrategy: legacyWidth !== null ? "sequential" : DEFAULTS.idStrategy,
       padWidth: legacyWidth !== null ? Math.max(legacyWidth, DEFAULTS.padWidth) : DEFAULTS.padWidth,
+      lint: { ...DEFAULT_LINT },
     };
   }
 
@@ -238,6 +291,8 @@ export function loadConfig(startDir?: string): Config {
   const slug = (parsed["slugify"] ?? {}) as Record<string, unknown>;
   const project = (parsed["project"] ?? {}) as Record<string, unknown>;
   const projectTags = (project["tags"] ?? {}) as Record<string, unknown>;
+  const lint = (parsed["lint"] ?? {}) as Record<string, unknown>;
+  const lintConventions = (lint["evergreen_conventions"] ?? {}) as Record<string, unknown>;
 
   const backlogRel = (paths["backlog_dir"] as string) ?? DEFAULTS.backlogDir;
   const archiveRel = (paths["archive_dir"] as string) ?? DEFAULTS.archiveDir;
@@ -342,6 +397,69 @@ export function loadConfig(startDir?: string): Config {
       testCommand: (project["test_command"] as string) ?? "",
       standardTags: (projectTags["standard"] as string[]) ?? [],
     },
+    lint: mergeLintConfig(lint, lintConventions),
+  };
+}
+
+function asStringArray(value: unknown, fallback: string[]): string[] {
+  if (Array.isArray(value)) {
+    return value.map((v) => String(v));
+  }
+  return fallback;
+}
+
+function asBool(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  return fallback;
+}
+
+function mergeLintConfig(
+  lint: Record<string, unknown>,
+  conventions: Record<string, unknown>
+): LintConfig {
+  const rawThreshold = lint["suggestion_threshold"];
+  let suggestionThreshold = DEFAULT_LINT.suggestionThreshold;
+  if (rawThreshold !== undefined) {
+    const n = typeof rawThreshold === "number" ? rawThreshold : Number(rawThreshold);
+    if (!Number.isFinite(n) || n < 0 || n > 1) {
+      throw new Error(
+        `Invalid [lint] suggestion_threshold: ${JSON.stringify(rawThreshold)}. ` +
+        `Must be a number between 0 and 1.`
+      );
+    }
+    suggestionThreshold = n;
+  }
+
+  return {
+    referenceDir: (lint["reference_dir"] as string) ?? DEFAULT_LINT.referenceDir,
+    referenceExclude: asStringArray(lint["reference_exclude"], DEFAULT_LINT.referenceExclude),
+    templateSourceDirs: asStringArray(lint["template_source_dirs"], DEFAULT_LINT.templateSourceDirs),
+    templateSourceFiles: asStringArray(lint["template_source_files"], DEFAULT_LINT.templateSourceFiles),
+    templatePatterns: asStringArray(lint["template_patterns"], DEFAULT_LINT.templatePatterns),
+    skipDirs: asStringArray(lint["skip_dirs"], DEFAULT_LINT.skipDirs),
+    evergreenConventions: {
+      requireFrontmatter: asBool(
+        conventions["require_frontmatter"],
+        DEFAULT_LINT.evergreenConventions.requireFrontmatter
+      ),
+      requireTitleField: asBool(
+        conventions["require_title_field"],
+        DEFAULT_LINT.evergreenConventions.requireTitleField
+      ),
+      requireTagsField: asBool(
+        conventions["require_tags_field"],
+        DEFAULT_LINT.evergreenConventions.requireTagsField
+      ),
+      requireRelatedSection: asBool(
+        conventions["require_related_section"],
+        DEFAULT_LINT.evergreenConventions.requireRelatedSection
+      ),
+      requireBodyWikilink: asBool(
+        conventions["require_body_wikilink"],
+        DEFAULT_LINT.evergreenConventions.requireBodyWikilink
+      ),
+    },
+    suggestionThreshold,
   };
 }
 
@@ -385,5 +503,19 @@ archive_dir = "archive"           # relative to backlog_dir
 
 # [project.tags]
 # standard = []
+
+# [lint]
+# reference_dir = "references"                                # flat reference notes
+# reference_exclude = ["tweets/"]                             # path fragments excluded from stale-reference check
+# template_source_dirs = [".claude/skills/", ".claude/rules/"] # docs that may contain placeholder wikilinks
+# template_source_files = ["CLAUDE.md"]
+# suggestion_threshold = 0.6                                  # min similarity for "did you mean?" hits
+
+# [lint.evergreen_conventions]
+# require_frontmatter = true
+# require_title_field = true
+# require_tags_field = true
+# require_related_section = true
+# require_body_wikilink = true
 `;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -277,7 +277,10 @@ export function loadConfig(startDir?: string): Config {
       evergreenDir: resolve(vaultRoot, DEFAULTS.evergreenDir),
       idStrategy: legacyWidth !== null ? "sequential" : DEFAULTS.idStrategy,
       padWidth: legacyWidth !== null ? Math.max(legacyWidth, DEFAULTS.padWidth) : DEFAULTS.padWidth,
-      lint: { ...DEFAULT_LINT },
+      lint: {
+        ...DEFAULT_LINT,
+        referenceDir: resolve(vaultRoot, DEFAULT_LINT.referenceDir),
+      },
     };
   }
 
@@ -397,7 +400,7 @@ export function loadConfig(startDir?: string): Config {
       testCommand: (project["test_command"] as string) ?? "",
       standardTags: (projectTags["standard"] as string[]) ?? [],
     },
-    lint: mergeLintConfig(lint, lintConventions),
+    lint: mergeLintConfig(vaultRoot, lint, lintConventions),
   };
 }
 
@@ -414,6 +417,7 @@ function asBool(value: unknown, fallback: boolean): boolean {
 }
 
 function mergeLintConfig(
+  vaultRoot: string,
   lint: Record<string, unknown>,
   conventions: Record<string, unknown>
 ): LintConfig {
@@ -430,12 +434,39 @@ function mergeLintConfig(
     suggestionThreshold = n;
   }
 
+  // referenceDir is the only filesystem path in the lint config — resolve it
+  // to absolute so callers can use it directly without re-resolving against
+  // CWD. The other arrays (templateSourceDirs, templateSourceFiles, skipDirs,
+  // referenceExclude) are not paths: they are vault-relative patterns matched
+  // against vault-relative posix strings during link collection and walking.
+  // Making them absolute would break the matching, so they stay as configured.
+  const referenceDirRaw = (lint["reference_dir"] as string) ?? DEFAULT_LINT.referenceDir;
+  const referenceDir = resolve(vaultRoot, referenceDirRaw);
+  if (relative(vaultRoot, referenceDir).startsWith("..")) {
+    throw new Error(`reference_dir must be inside the vault root`);
+  }
+
+  const templatePatterns = asStringArray(lint["template_patterns"], DEFAULT_LINT.templatePatterns);
+  // Validate patterns at config-load time so a typo surfaces with a clear
+  // message and a file:line pointer to the config, not a stack trace from
+  // inside the link collector.
+  templatePatterns.forEach((p, i) => {
+    try {
+      new RegExp(p);
+    } catch (err) {
+      throw new Error(
+        `Invalid [lint] template_patterns[${i}]: ${JSON.stringify(p)}. ` +
+        `${(err as Error).message}`
+      );
+    }
+  });
+
   return {
-    referenceDir: (lint["reference_dir"] as string) ?? DEFAULT_LINT.referenceDir,
+    referenceDir,
     referenceExclude: asStringArray(lint["reference_exclude"], DEFAULT_LINT.referenceExclude),
     templateSourceDirs: asStringArray(lint["template_source_dirs"], DEFAULT_LINT.templateSourceDirs),
     templateSourceFiles: asStringArray(lint["template_source_files"], DEFAULT_LINT.templateSourceFiles),
-    templatePatterns: asStringArray(lint["template_patterns"], DEFAULT_LINT.templatePatterns),
+    templatePatterns,
     skipDirs: asStringArray(lint["skip_dirs"], DEFAULT_LINT.skipDirs),
     evergreenConventions: {
       requireFrontmatter: asBool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,41 @@
 export type { Task, CreateTaskOpts } from "./task.js";
-export type { Config } from "./config.js";
+export type { Config, LintConfig, LintEvergreenConventions } from "./config.js";
 export { TaskStore } from "./store.js";
 export { loadConfig, findConfigFile } from "./config.js";
 export { parseFrontmatter, writeFrontmatter } from "./frontmatter.js";
 export { slugify } from "./slugify.js";
 export { generateUlid, isValidUlid } from "./ulid.js";
+
+export {
+  lintVault,
+  buildIndex,
+  resolveTarget,
+  stripTargetSuffixes,
+  normKey,
+  collectWikilinks,
+  readVaultFiles,
+  isTemplatePlaceholder,
+  findBrokenLinks,
+  buildInboundMap,
+  findOrphanEvergreens,
+  findStaleReferences,
+  findEvergreenDrift,
+  attachSuggestions,
+  computeLeverageFixes,
+  formatHumanReport,
+  formatJsonReport,
+  formatSummaryLine,
+} from "./lint/index.js";
+
+export type {
+  LintReport,
+  LintOptions,
+  WikiLink,
+  VaultFile,
+  ResolutionIndex,
+  Suggestion,
+  BrokenEntry,
+  LeverageFix,
+  DriftEntry,
+  CheckName,
+} from "./lint/types.js";

--- a/src/lint/checks/broken.ts
+++ b/src/lint/checks/broken.ts
@@ -1,0 +1,43 @@
+/**
+ * Broken-wikilink detection.
+ *
+ * For each link, attempt resolution against the index. Links that fail to
+ * resolve are aggregated by target so a single missing file shows up as one
+ * row with a count, not N noisy rows. Output is sorted by frequency
+ * descending — the most-broken target is the highest-leverage fix.
+ */
+
+import type { ResolutionIndex, BrokenEntry, WikiLink } from "../types.js";
+import { resolveTarget } from "../resolve.js";
+
+export function findBrokenLinks(
+  links: WikiLink[],
+  index: ResolutionIndex
+): BrokenEntry[] {
+  const buckets = new Map<string, BrokenEntry>();
+
+  for (const link of links) {
+    const resolved = resolveTarget(link.target, index);
+    if (resolved !== null) continue;
+
+    const existing = buckets.get(link.target);
+    if (existing) {
+      existing.count += 1;
+      existing.locations.push({ source: link.source, line: link.line });
+    } else {
+      buckets.set(link.target, {
+        target: link.target,
+        count: 1,
+        locations: [{ source: link.source, line: link.line }],
+        suggestions: [],
+      });
+    }
+  }
+
+  const entries = [...buckets.values()];
+  entries.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.target.localeCompare(b.target);
+  });
+  return entries;
+}

--- a/src/lint/checks/drift.ts
+++ b/src/lint/checks/drift.ts
@@ -1,0 +1,64 @@
+/**
+ * Convention-drift detection on evergreens.
+ *
+ * Evergreens have a strong shape: frontmatter with title and tags, body
+ * with at least one wikilink, and a `## Related` section anchoring the
+ * note in the graph. Drift here surfaces evergreens that fell out of that
+ * shape — usually because they were dropped in by hand or by an earlier
+ * iteration of a skill that has since changed. Each requirement is
+ * individually configurable. Files opt out per-file via
+ * `lint_drift_ok: true` in frontmatter.
+ */
+
+import type { LintEvergreenConventions } from "../../config.js";
+import type { DriftEntry, VaultFile } from "../types.js";
+
+const README_STEMS = new Set(["README", "readme", "Readme", "index", "INDEX", "Index"]);
+const RELATED_HEADING_RE = /^##+\s+Related\b/m;
+const ANY_WIKILINK_RE = /\[\[[^\]\n]+\]\]/;
+
+function basenameStem(relPath: string): string {
+  const slash = relPath.lastIndexOf("/");
+  const tail = slash >= 0 ? relPath.slice(slash + 1) : relPath;
+  return tail.replace(/\.md$/, "");
+}
+
+export function findEvergreenDrift(
+  files: VaultFile[],
+  evergreenDirRel: string,
+  conventions: LintEvergreenConventions
+): DriftEntry[] {
+  const dirPrefix = evergreenDirRel.replace(/\/+$/, "");
+  if (!dirPrefix) return [];
+
+  const out: DriftEntry[] = [];
+  for (const f of files) {
+    if (f.relPath !== dirPrefix && !f.relPath.startsWith(`${dirPrefix}/`)) continue;
+    if (README_STEMS.has(basenameStem(f.relPath))) continue;
+    if (f.lintOpts.driftOk) continue;
+
+    const issues: string[] = [];
+    if (conventions.requireFrontmatter && !f.hasFrontmatter) {
+      issues.push("no frontmatter");
+    } else {
+      if (conventions.requireTitleField && !f.title) {
+        issues.push("no title field");
+      }
+      if (conventions.requireTagsField && !f.hasTagsField) {
+        issues.push("no tags field");
+      }
+    }
+    if (conventions.requireBodyWikilink && !ANY_WIKILINK_RE.test(f.body)) {
+      issues.push("no wikilinks in body");
+    }
+    if (conventions.requireRelatedSection && !RELATED_HEADING_RE.test(f.text)) {
+      issues.push("no ## Related section");
+    }
+
+    if (issues.length > 0) {
+      out.push({ filePath: f.relPath, issues });
+    }
+  }
+  out.sort((a, b) => a.filePath.localeCompare(b.filePath));
+  return out;
+}

--- a/src/lint/checks/orphans.ts
+++ b/src/lint/checks/orphans.ts
@@ -1,0 +1,68 @@
+/**
+ * Orphan-evergreen detection.
+ *
+ * An evergreen note is "orphaned" when no other file links to it. This is
+ * almost always a bug — evergreens earn their keep by being referenced — so
+ * the lint surfaces them. Files that are intentionally orphan (inboxes,
+ * drafts) can opt out via `lint_orphan_ok: true` in frontmatter.
+ *
+ * Implementation: build the inbound-link map from the resolved-link list
+ * once, then filter the evergreen file list against it. Self-references do
+ * not count as inbound. README files are exempt.
+ */
+
+import { resolveTarget } from "../resolve.js";
+import type { ResolutionIndex, VaultFile, WikiLink } from "../types.js";
+
+const README_STEMS = new Set(["README", "readme", "Readme", "index", "INDEX", "Index"]);
+
+function basenameStem(relPath: string): string {
+  const slash = relPath.lastIndexOf("/");
+  const tail = slash >= 0 ? relPath.slice(slash + 1) : relPath;
+  return tail.replace(/\.md$/, "");
+}
+
+/**
+ * Compute, for every file, the set of distinct source files that link to it
+ * via any resolvable wikilink. Used by both orphan and stale checks.
+ */
+export function buildInboundMap(
+  links: WikiLink[],
+  index: ResolutionIndex
+): Map<string, Set<string>> {
+  const inbound = new Map<string, Set<string>>();
+  for (const link of links) {
+    const resolved = resolveTarget(link.target, index);
+    if (resolved === null) continue;
+    if (resolved === link.source) continue;
+    let set = inbound.get(resolved);
+    if (!set) {
+      set = new Set();
+      inbound.set(resolved, set);
+    }
+    set.add(link.source);
+  }
+  return inbound;
+}
+
+export function findOrphanEvergreens(
+  files: VaultFile[],
+  inbound: Map<string, Set<string>>,
+  evergreenDirRel: string
+): string[] {
+  const dirPrefix = evergreenDirRel.replace(/\/+$/, "");
+  if (!dirPrefix) return [];
+
+  const out: string[] = [];
+  for (const f of files) {
+    if (f.relPath !== `${dirPrefix}` && !f.relPath.startsWith(`${dirPrefix}/`)) continue;
+    if (README_STEMS.has(basenameStem(f.relPath))) continue;
+    if (f.lintOpts.orphanOk) continue;
+    const incoming = inbound.get(f.relPath);
+    if (!incoming || incoming.size === 0) {
+      out.push(f.relPath);
+    }
+  }
+  out.sort();
+  return out;
+}

--- a/src/lint/checks/stale.ts
+++ b/src/lint/checks/stale.ts
@@ -1,0 +1,54 @@
+/**
+ * Stale-reference detection.
+ *
+ * A reference note is "stale" when nothing in the vault links to it. Same
+ * mechanism as orphan-evergreen detection, but scoped to the references
+ * directory and respecting per-vault path exclusions (e.g. `tweets/`).
+ * Files can opt out via `lint_stale_ok: true` in frontmatter.
+ */
+
+import type { VaultFile } from "../types.js";
+
+const README_STEMS = new Set(["README", "readme", "Readme", "index", "INDEX", "Index"]);
+
+function basenameStem(relPath: string): string {
+  const slash = relPath.lastIndexOf("/");
+  const tail = slash >= 0 ? relPath.slice(slash + 1) : relPath;
+  return tail.replace(/\.md$/, "");
+}
+
+export function findStaleReferences(
+  files: VaultFile[],
+  inbound: Map<string, Set<string>>,
+  referenceDirRel: string,
+  referenceExclude: string[]
+): string[] {
+  const dirPrefix = referenceDirRel.replace(/\/+$/, "");
+  if (!dirPrefix) return [];
+
+  const out: string[] = [];
+  for (const f of files) {
+    if (f.relPath !== dirPrefix && !f.relPath.startsWith(`${dirPrefix}/`)) continue;
+    if (README_STEMS.has(basenameStem(f.relPath))) continue;
+    if (f.lintOpts.staleOk) continue;
+    const excluded = referenceExclude.some((pattern) => {
+      if (!pattern) return false;
+      const trimmed = pattern.replace(/\/+$/, "");
+      if (!trimmed) return false;
+      // Match the pattern as either a leading subdir (relative to the
+      // reference root) or anywhere in the path.
+      return (
+        f.relPath.includes(`/${trimmed}/`) ||
+        f.relPath.startsWith(`${dirPrefix}/${trimmed}/`)
+      );
+    });
+    if (excluded) continue;
+
+    const incoming = inbound.get(f.relPath);
+    if (!incoming || incoming.size === 0) {
+      out.push(f.relPath);
+    }
+  }
+  out.sort();
+  return out;
+}

--- a/src/lint/collect.ts
+++ b/src/lint/collect.ts
@@ -13,7 +13,7 @@
  *   `~~~`-fenced blocks are also not recognised.
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 import { parseFrontmatter } from "../frontmatter.js";
 import { stripTargetSuffixes } from "./resolve.js";
@@ -39,8 +39,14 @@ function pathHitsSkipDir(relPosix: string, skipDirs: string[]): boolean {
 
 /**
  * Recursively walk the vault and yield .md files, respecting skipDirs.
- * Symlinks are not followed (statSync is used; the entry's target is
- * resolved, but loops are bounded by the vault root).
+ *
+ * Symlinks are deliberately NOT followed: a symlinked directory inside the
+ * vault could otherwise point at `/etc` or any other location outside the
+ * vault root, and a read-only audit has no business resolving them. We use
+ * `lstatSync` (not `statSync`) so symlinks report as symlinks rather than
+ * as their resolved target, and skip them. As an additional defence, we
+ * verify each candidate stays under the vault root via `relative()` — this
+ * catches any hardlinks or weird mount situations that lstat might miss.
  */
 export function walkMarkdown(
   vaultRoot: string,
@@ -59,17 +65,30 @@ export function walkMarkdown(
     }
 
     for (const name of entries) {
-      // Always skip dotfiles at top level except known content dirs would
-      // have been removed by skipDirs anyway. Walk dotted dirs only if the
-      // user explicitly opts in by removing them from skipDirs.
       const abs = join(dir, name);
+
+      // Containment check: relative path must not start with `..`. This
+      // is a belt-and-suspenders check — `join()` collapses `..` segments,
+      // so this can only fire for genuinely escaping paths.
+      const rel = toRelPosix(abs, vaultRoot);
+      if (rel.startsWith("../") || rel === "..") {
+        onWarn(`skipping path outside vault root: ${abs}`);
+        continue;
+      }
+
       let st;
       try {
-        st = statSync(abs);
+        st = lstatSync(abs);
       } catch {
         continue;
       }
-      const rel = toRelPosix(abs, vaultRoot);
+
+      // Skip symlinks (regardless of target). Following them risks reading
+      // outside the vault root and creating cycles.
+      if (st.isSymbolicLink()) {
+        continue;
+      }
+
       if (pathHitsSkipDir(rel, skipDirs)) continue;
       if (st.isDirectory()) {
         recurse(abs);

--- a/src/lint/collect.ts
+++ b/src/lint/collect.ts
@@ -1,0 +1,240 @@
+/**
+ * Vault walking, frontmatter extraction, and wikilink collection.
+ *
+ * Code-block awareness:
+ * - Triple-backtick fenced blocks are tracked line-by-line and skipped.
+ * - Inline `code spans` are stripped from each non-fenced line before regex
+ *   scanning.
+ *
+ * Limitations (acceptable for vault-scale audits; called out for future me):
+ * - Inline code regex uses a single backtick per side. Backtick-escaped
+ *   sequences and double/triple inline spans are not handled.
+ * - Fenced-block tracking does not match opening/closing fence lengths.
+ *   `~~~`-fenced blocks are also not recognised.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { parseFrontmatter } from "../frontmatter.js";
+import { stripTargetSuffixes } from "./resolve.js";
+import type { VaultFile, WikiLink } from "./types.js";
+
+const WIKILINK_RE = /\[\[([^\]\n]+?)\]\]/g;
+const INLINE_CODE_RE = /`[^`\n]*`/g;
+
+function toRelPosix(absPath: string, vaultRoot: string): string {
+  return relative(vaultRoot, absPath).split(sep).join("/");
+}
+
+function pathHitsSkipDir(relPosix: string, skipDirs: string[]): boolean {
+  for (const d of skipDirs) {
+    const trimmed = d.replace(/\/+$/, "");
+    if (!trimmed) continue;
+    if (relPosix === trimmed) return true;
+    if (relPosix.startsWith(`${trimmed}/`)) return true;
+    if (relPosix.includes(`/${trimmed}/`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Recursively walk the vault and yield .md files, respecting skipDirs.
+ * Symlinks are not followed (statSync is used; the entry's target is
+ * resolved, but loops are bounded by the vault root).
+ */
+export function walkMarkdown(
+  vaultRoot: string,
+  skipDirs: string[],
+  onWarn: (msg: string) => void
+): string[] {
+  const out: string[] = [];
+
+  const recurse = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch (err) {
+      onWarn(`could not read directory ${dir}: ${(err as Error).message}`);
+      return;
+    }
+
+    for (const name of entries) {
+      // Always skip dotfiles at top level except known content dirs would
+      // have been removed by skipDirs anyway. Walk dotted dirs only if the
+      // user explicitly opts in by removing them from skipDirs.
+      const abs = join(dir, name);
+      let st;
+      try {
+        st = statSync(abs);
+      } catch {
+        continue;
+      }
+      const rel = toRelPosix(abs, vaultRoot);
+      if (pathHitsSkipDir(rel, skipDirs)) continue;
+      if (st.isDirectory()) {
+        recurse(abs);
+      } else if (st.isFile() && name.endsWith(".md")) {
+        out.push(abs);
+      }
+    }
+  };
+
+  recurse(vaultRoot);
+  out.sort();
+  return out;
+}
+
+function extractAliases(meta: Record<string, unknown>): string[] {
+  const raw = meta["aliases"];
+  if (Array.isArray(raw)) {
+    return raw.map((v) => String(v)).filter((s) => s.length > 0);
+  }
+  if (typeof raw === "string" && raw.length > 0) {
+    return [raw];
+  }
+  return [];
+}
+
+function readBoolFlag(meta: Record<string, unknown>, key: string): boolean {
+  const v = meta[key];
+  if (typeof v === "boolean") return v;
+  if (typeof v === "string") {
+    const lc = v.toLowerCase();
+    return lc === "true" || lc === "yes" || lc === "ok" || lc === "1";
+  }
+  return false;
+}
+
+/**
+ * Read and parse all .md files in the vault into VaultFile records.
+ */
+export function readVaultFiles(
+  vaultRoot: string,
+  skipDirs: string[],
+  onWarn: (msg: string) => void
+): VaultFile[] {
+  const absPaths = walkMarkdown(vaultRoot, skipDirs, onWarn);
+  const files: VaultFile[] = [];
+
+  for (const abs of absPaths) {
+    let text: string;
+    try {
+      text = readFileSync(abs, "utf-8");
+    } catch (err) {
+      onWarn(`could not read ${toRelPosix(abs, vaultRoot)}: ${(err as Error).message}`);
+      continue;
+    }
+    const normalised = text.replace(/\r\n/g, "\n");
+    const { meta, body } = parseFrontmatter(normalised);
+    const hasFrontmatter = Object.keys(meta).length > 0 || normalised.startsWith("---\n");
+    const hasTagsField = Object.prototype.hasOwnProperty.call(meta, "tags");
+    const titleRaw = meta["title"];
+    const title = typeof titleRaw === "string" && titleRaw.length > 0 ? titleRaw : null;
+
+    files.push({
+      relPath: toRelPosix(abs, vaultRoot),
+      absPath: abs,
+      title,
+      aliases: extractAliases(meta),
+      hasFrontmatter,
+      hasTagsField,
+      body,
+      text: normalised,
+      lintOpts: {
+        orphanOk: readBoolFlag(meta, "lint_orphan_ok"),
+        staleOk: readBoolFlag(meta, "lint_stale_ok"),
+        driftOk: readBoolFlag(meta, "lint_drift_ok"),
+      },
+    });
+  }
+
+  return files;
+}
+
+/**
+ * Determine whether a wikilink target should be skipped because it appears
+ * in a documentation file (skill/rule/CLAUDE.md) AND matches a known
+ * placeholder pattern.
+ */
+export function isTemplatePlaceholder(
+  target: string,
+  source: string,
+  templateSourceDirs: string[],
+  templateSourceFiles: string[],
+  templatePatterns: RegExp[]
+): boolean {
+  let inTemplateSource = false;
+  for (const dir of templateSourceDirs) {
+    const trimmed = dir.replace(/\/+$/, "");
+    if (!trimmed) continue;
+    if (source === trimmed || source.startsWith(`${trimmed}/`)) {
+      inTemplateSource = true;
+      break;
+    }
+  }
+  if (!inTemplateSource) {
+    for (const f of templateSourceFiles) {
+      if (source === f) {
+        inTemplateSource = true;
+        break;
+      }
+    }
+  }
+  if (!inTemplateSource) return false;
+
+  for (const re of templatePatterns) {
+    if (re.test(target)) return true;
+  }
+  return false;
+}
+
+/**
+ * Scan a list of VaultFile records for wikilinks, skipping fenced code
+ * blocks and inline code spans, plus any link that matches a template
+ * placeholder pattern when it lives in a known template source.
+ */
+export function collectWikilinks(
+  files: VaultFile[],
+  templateSourceDirs: string[],
+  templateSourceFiles: string[],
+  templatePatterns: string[]
+): WikiLink[] {
+  const compiled = templatePatterns.map((p) => new RegExp(p));
+  const out: WikiLink[] = [];
+
+  for (const f of files) {
+    const lines = f.text.split("\n");
+    let inFence = false;
+    for (let i = 0; i < lines.length; i++) {
+      const raw = lines[i];
+      const stripped = raw.trimStart();
+      if (stripped.startsWith("```")) {
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
+
+      const cleaned = raw.replace(INLINE_CODE_RE, "");
+      WIKILINK_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = WIKILINK_RE.exec(cleaned)) !== null) {
+        const target = stripTargetSuffixes(m[1]);
+        if (!target) continue;
+        if (
+          isTemplatePlaceholder(
+            target,
+            f.relPath,
+            templateSourceDirs,
+            templateSourceFiles,
+            compiled
+          )
+        ) {
+          continue;
+        }
+        out.push({ target, source: f.relPath, line: i + 1 });
+      }
+    }
+  }
+
+  return out;
+}

--- a/src/lint/index.ts
+++ b/src/lint/index.ts
@@ -1,0 +1,148 @@
+/**
+ * Vault lint orchestrator.
+ *
+ * Walks the vault, builds the resolution index, runs the four checks
+ * (broken / orphans / stale / drift), attaches "did you mean?" suggestions
+ * to broken links, and returns a LintReport. Read-only by design; never
+ * writes to the vault.
+ *
+ * The orchestrator is structured so callers can run a subset of checks
+ * (`only`) or scope to a subtree (`scope`). Resolution always uses the full
+ * vault index — scoping a check to a subtree should not cause links inside
+ * that subtree to look broken just because their target is outside it.
+ */
+
+import { relative, resolve, sep } from "node:path";
+import type { Config } from "../config.js";
+import { findBrokenLinks } from "./checks/broken.js";
+import { findEvergreenDrift } from "./checks/drift.js";
+import { buildInboundMap, findOrphanEvergreens } from "./checks/orphans.js";
+import { findStaleReferences } from "./checks/stale.js";
+import { collectWikilinks, readVaultFiles } from "./collect.js";
+import { buildIndex } from "./resolve.js";
+import { attachSuggestions, computeLeverageFixes } from "./suggest.js";
+import type { LintOptions, LintReport, VaultFile } from "./types.js";
+
+export * from "./types.js";
+export { buildIndex, normKey, resolveTarget, stripTargetSuffixes } from "./resolve.js";
+export { collectWikilinks, isTemplatePlaceholder, readVaultFiles } from "./collect.js";
+export { findBrokenLinks } from "./checks/broken.js";
+export { buildInboundMap, findOrphanEvergreens } from "./checks/orphans.js";
+export { findStaleReferences } from "./checks/stale.js";
+export { findEvergreenDrift } from "./checks/drift.js";
+export { attachSuggestions, computeLeverageFixes } from "./suggest.js";
+export { formatHumanReport, formatJsonReport, formatSummaryLine } from "./report.js";
+
+function toRelPosix(absPath: string, vaultRoot: string): string {
+  return relative(vaultRoot, absPath).split(sep).join("/");
+}
+
+function relPathPosix(p: string): string {
+  return p.split(sep).join("/");
+}
+
+function normaliseScope(scope: string | undefined): string | null {
+  if (!scope) return null;
+  const cleaned = relPathPosix(scope).replace(/^\.\/+/, "").replace(/\/+$/, "");
+  return cleaned === "" ? null : cleaned;
+}
+
+function inScope(relPath: string, scope: string | null): boolean {
+  if (scope === null) return true;
+  return relPath === scope || relPath.startsWith(`${scope}/`);
+}
+
+/**
+ * Run the lint checks against a vault and return a structured report.
+ */
+export function lintVault(config: Config, opts: LintOptions = {}): LintReport {
+  const warnings: string[] = [];
+  const onWarn = opts.onWarn ?? ((msg) => warnings.push(msg));
+
+  const lint = config.lint;
+  const evergreenDirRel = toRelPosix(config.evergreenDir, config.vaultRoot);
+  const referenceDirRel = toRelPosix(
+    resolve(config.vaultRoot, lint.referenceDir),
+    config.vaultRoot
+  );
+
+  const allFiles = readVaultFiles(config.vaultRoot, lint.skipDirs, onWarn);
+  const index = buildIndex(allFiles);
+
+  for (const [key, paths] of index.collisions) {
+    warnings.push(
+      `${paths.length} files share normalised key '${key}': ${paths.join(", ")}`
+    );
+  }
+
+  const scope = normaliseScope(opts.scope);
+  const scopedFiles: VaultFile[] = scope === null
+    ? allFiles
+    : allFiles.filter((f) => inScope(f.relPath, scope));
+
+  const allLinks = collectWikilinks(
+    allFiles,
+    lint.templateSourceDirs,
+    lint.templateSourceFiles,
+    lint.templatePatterns
+  );
+
+  const scopedLinks = scope === null
+    ? allLinks
+    : allLinks.filter((l) => inScope(l.source, scope));
+
+  const inbound = buildInboundMap(allLinks, index);
+
+  const wantBroken = !opts.only || opts.only === "broken";
+  const wantOrphans = !opts.only || opts.only === "orphans";
+  const wantStale = !opts.only || opts.only === "stale";
+  const wantDrift = !opts.only || opts.only === "drift";
+
+  const broken = wantBroken ? findBrokenLinks(scopedLinks, index) : [];
+  if (wantBroken && !opts.noSuggestions) {
+    attachSuggestions(broken, index, lint.suggestionThreshold);
+  }
+  const leverageFixes = wantBroken && !opts.noSuggestions
+    ? computeLeverageFixes(broken)
+    : [];
+
+  const orphans = wantOrphans
+    ? findOrphanEvergreens(scopedFiles, inbound, evergreenDirRel)
+    : [];
+
+  const stale = wantStale
+    ? findStaleReferences(
+        scopedFiles,
+        inbound,
+        referenceDirRel,
+        lint.referenceExclude
+      )
+    : [];
+
+  const drift = wantDrift
+    ? findEvergreenDrift(scopedFiles, evergreenDirRel, lint.evergreenConventions)
+    : [];
+
+  const summary = {
+    broken: broken.length,
+    orphans: orphans.length,
+    stale: stale.length,
+    drift: drift.length,
+  };
+  const hasIssues =
+    summary.broken > 0 ||
+    summary.orphans > 0 ||
+    summary.stale > 0 ||
+    summary.drift > 0;
+
+  return {
+    broken,
+    orphans,
+    stale,
+    drift,
+    leverageFixes,
+    warnings,
+    summary,
+    hasIssues,
+  };
+}

--- a/src/lint/index.ts
+++ b/src/lint/index.ts
@@ -12,7 +12,7 @@
  * that subtree to look broken just because their target is outside it.
  */
 
-import { relative, resolve, sep } from "node:path";
+import { relative, sep } from "node:path";
 import type { Config } from "../config.js";
 import { findBrokenLinks } from "./checks/broken.js";
 import { findEvergreenDrift } from "./checks/drift.js";
@@ -57,20 +57,24 @@ function inScope(relPath: string, scope: string | null): boolean {
  */
 export function lintVault(config: Config, opts: LintOptions = {}): LintReport {
   const warnings: string[] = [];
-  const onWarn = opts.onWarn ?? ((msg) => warnings.push(msg));
+  // Always accumulate into the report; forward to opts.onWarn if provided.
+  // The report's `warnings` field is what `--json` and `formatHumanReport`
+  // surface, so dropping warnings when a callback is set silently degrades
+  // the JSON output.
+  const onWarn = (msg: string): void => {
+    warnings.push(msg);
+    opts.onWarn?.(msg);
+  };
 
   const lint = config.lint;
   const evergreenDirRel = toRelPosix(config.evergreenDir, config.vaultRoot);
-  const referenceDirRel = toRelPosix(
-    resolve(config.vaultRoot, lint.referenceDir),
-    config.vaultRoot
-  );
+  const referenceDirRel = toRelPosix(lint.referenceDir, config.vaultRoot);
 
   const allFiles = readVaultFiles(config.vaultRoot, lint.skipDirs, onWarn);
   const index = buildIndex(allFiles);
 
   for (const [key, paths] of index.collisions) {
-    warnings.push(
+    onWarn(
       `${paths.length} files share normalised key '${key}': ${paths.join(", ")}`
     );
   }

--- a/src/lint/report.ts
+++ b/src/lint/report.ts
@@ -1,0 +1,92 @@
+/**
+ * Human-readable and JSON formatters for a LintReport.
+ *
+ * The human format is shaped for solo-dev terminal review. The JSON format
+ * preserves the full report data for CI dashboards and downstream tooling.
+ */
+
+import type { LintReport } from "./types.js";
+
+const MAX_LOCATIONS_PER_TARGET = 3;
+
+function formatSimilarity(n: number): string {
+  return n.toFixed(2);
+}
+
+export function formatSummaryLine(report: LintReport): string {
+  const { broken, orphans, stale, drift } = report.summary;
+  return `SUMMARY: broken:${broken} orphans:${orphans} stale:${stale} drift:${drift}`;
+}
+
+export function formatHumanReport(report: LintReport): string {
+  const out: string[] = [];
+
+  if (report.warnings.length > 0) {
+    out.push(`=== WARNINGS (${report.warnings.length}) ===`);
+    for (const w of report.warnings) {
+      out.push(`  ${w}`);
+    }
+    out.push("");
+  }
+
+  if (report.leverageFixes.length > 0) {
+    out.push(`=== HIGH-LEVERAGE FIXES (${report.leverageFixes.length}) ===`);
+    for (const fix of report.leverageFixes) {
+      const aliasList = fix.aliases.length === 1
+        ? `[${fix.aliases[0]}]`
+        : `[${fix.aliases.join(", ")}]`;
+      out.push(`  ${fix.action}: aliases ${aliasList}  closes ${fix.closes} broken link${fix.closes === 1 ? "" : "s"}`);
+    }
+    out.push("");
+  }
+
+  out.push(`=== BROKEN WIKILINKS (${report.broken.length}) ===`);
+  for (const entry of report.broken) {
+    out.push(`  [[${entry.target}]]  (${entry.count} occurrence${entry.count === 1 ? "" : "s"})`);
+    for (const sugg of entry.suggestions) {
+      out.push(
+        `    suggest: ${sugg.filePath}  (sim ${formatSimilarity(sugg.similarity)}, ${sugg.kind} "${sugg.candidate}")`
+      );
+      if (sugg.kind !== "alias") {
+        out.push(`      → adding \`aliases: [${sugg.proposedAlias}]\` to that file would close all ${entry.count}`);
+      }
+    }
+    const limit = MAX_LOCATIONS_PER_TARGET;
+    const visible = entry.locations.slice(0, limit);
+    if (visible.length > 0) {
+      out.push(`    locations:`);
+      for (const loc of visible) {
+        out.push(`      ${loc.source}:${loc.line}`);
+      }
+      if (entry.locations.length > visible.length) {
+        out.push(`      ... +${entry.locations.length - visible.length} more`);
+      }
+    }
+  }
+  out.push("");
+
+  out.push(`=== ORPHAN EVERGREENS (${report.orphans.length}) ===`);
+  for (const o of report.orphans) {
+    out.push(`  ${o}`);
+  }
+  out.push("");
+
+  out.push(`=== STALE REFERENCES (${report.stale.length}) ===`);
+  for (const s of report.stale) {
+    out.push(`  ${s}`);
+  }
+  out.push("");
+
+  out.push(`=== CONVENTION DRIFT (${report.drift.length}) ===`);
+  for (const d of report.drift) {
+    out.push(`  ${d.filePath}: ${d.issues.join(", ")}`);
+  }
+  out.push("");
+
+  out.push(formatSummaryLine(report));
+  return out.join("\n");
+}
+
+export function formatJsonReport(report: LintReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/src/lint/resolve.ts
+++ b/src/lint/resolve.ts
@@ -1,0 +1,160 @@
+/**
+ * Wikilink resolution — Obsidian-correct, performance-tuned.
+ *
+ * Resolution rules (mirrors Obsidian; covered by tests):
+ * 1. Case-insensitive; whitespace, hyphen, underscore, and colon are
+ *    interchangeable in the target. `[[Foo Bar]]`, `[[foo-bar]]`,
+ *    `[[FOO_BAR]]` all resolve to the same key.
+ * 2. Targets resolve against three sources of truth per file:
+ *      - filename stem (basename without `.md`)
+ *      - full vault-relative path stem (path without `.md`)
+ *      - `title:` frontmatter value
+ *      - any value in `aliases:` frontmatter
+ * 3. Path-form targets (`[[10-areas/foo/CONTEXT]]`) resolve to the file at
+ *    that exact path stem.
+ * 4. Partial-path tails resolve when the suffix uniquely identifies a file:
+ *    `[[parenting/CONTEXT]]` → `10-areas/parenting/CONTEXT.md` if no other
+ *    file ends in `parenting/CONTEXT`. Built from a precomputed tail index
+ *    so resolution is O(1) instead of O(N) per link.
+ * 5. `|alias` and `#anchor` suffixes are stripped before resolution.
+ */
+
+import type { ResolutionIndex, VaultFile } from "./types.js";
+
+/** Strip the `|display-text` and `#section-anchor` suffixes from a target. */
+export function stripTargetSuffixes(raw: string): string {
+  const noAlias = raw.split("|", 1)[0];
+  const noAnchor = noAlias.split("#", 1)[0];
+  return noAnchor.trim();
+}
+
+/**
+ * Normalise a key for resolution lookup: lowercase, strip whitespace,
+ * hyphens, underscores, and colons. Slashes are preserved so path-form
+ * keys remain distinguishable from flat-name keys.
+ */
+export function normKey(s: string): string {
+  return s.toLowerCase().replace(/[\s\-_:]+/g, "");
+}
+
+function pathStem(relPath: string): string {
+  return relPath.endsWith(".md") ? relPath.slice(0, -3) : relPath;
+}
+
+function basenameOf(relPath: string): string {
+  const slash = relPath.lastIndexOf("/");
+  const tail = slash >= 0 ? relPath.slice(slash + 1) : relPath;
+  return tail.endsWith(".md") ? tail.slice(0, -3) : tail;
+}
+
+/**
+ * Build the resolution index from a list of vault files.
+ *
+ * Collisions (multiple files sharing a normalised key) are recorded but do
+ * not prevent registration: resolution returns null for collided keys so the
+ * link is reported as broken rather than silently mapping to an arbitrary
+ * file. This is a deliberate change from the reference Python script, which
+ * silently let the last-registered file win.
+ */
+export function buildIndex(files: VaultFile[]): ResolutionIndex {
+  const exact = new Map<string, string[]>();
+  const tail = new Map<string, string[]>();
+  const byPath = new Map<string, VaultFile>();
+
+  const addExact = (key: string, path: string): void => {
+    if (!key) return;
+    const list = exact.get(key);
+    if (list) {
+      if (!list.includes(path)) list.push(path);
+    } else {
+      exact.set(key, [path]);
+    }
+  };
+
+  const addTail = (key: string, path: string): void => {
+    if (!key) return;
+    const list = tail.get(key);
+    if (list) {
+      if (!list.includes(path)) list.push(path);
+    } else {
+      tail.set(key, [path]);
+    }
+  };
+
+  for (const f of files) {
+    byPath.set(f.relPath, f);
+
+    const stem = pathStem(f.relPath);
+    const base = basenameOf(f.relPath);
+
+    addExact(normKey(base), f.relPath);
+    addExact(normKey(stem), f.relPath);
+
+    if (f.title) addExact(normKey(f.title), f.relPath);
+    for (const alias of f.aliases) {
+      if (alias) addExact(normKey(alias), f.relPath);
+    }
+
+    // Tail index: register every multi-component path suffix.
+    // For 10-areas/parenting/CONTEXT this registers parenting/CONTEXT.
+    // Single-component tails are already covered by basename in `exact`.
+    const components = stem.split("/").filter((c) => c !== "");
+    for (let i = 1; i < components.length; i++) {
+      const suffix = components.slice(i).join("/");
+      // Only register multi-component suffixes — single component would be
+      // the basename, already handled by exact lookup.
+      if (suffix.includes("/")) {
+        addTail(normKey(suffix), f.relPath);
+      }
+    }
+  }
+
+  const collisions = new Map<string, string[]>();
+  for (const [key, paths] of exact) {
+    if (paths.length > 1) collisions.set(key, [...paths]);
+  }
+  for (const [key, paths] of tail) {
+    if (paths.length > 1 && !collisions.has(key)) {
+      collisions.set(key, [...paths]);
+    }
+  }
+
+  return { exact, tail, files, byPath, collisions };
+}
+
+/**
+ * Resolve a wikilink target to a vault-relative path, or null.
+ *
+ * Returns null for both "not found" and "ambiguous" — the caller cannot tell
+ * the two apart by design. Ambiguous targets must be disambiguated by the
+ * author before they have a defined meaning.
+ */
+export function resolveTarget(
+  rawTarget: string,
+  index: ResolutionIndex
+): string | null {
+  const target = stripTargetSuffixes(rawTarget);
+  if (!target) return null;
+
+  const key = normKey(target);
+
+  const exactMatches = index.exact.get(key);
+  if (exactMatches && exactMatches.length === 1) {
+    return exactMatches[0];
+  }
+  if (exactMatches && exactMatches.length > 1) {
+    // Ambiguous: don't guess. The collision is already recorded in
+    // index.collisions and surfaced as a warning by the orchestrator.
+    return null;
+  }
+
+  if (target.includes("/")) {
+    const tailMatches = index.tail.get(key);
+    if (tailMatches && tailMatches.length === 1) {
+      return tailMatches[0];
+    }
+    // Multiple tail matches → ambiguous → not resolved.
+  }
+
+  return null;
+}

--- a/src/lint/suggest.ts
+++ b/src/lint/suggest.ts
@@ -1,0 +1,140 @@
+/**
+ * "Did you mean?" suggestions for broken wikilink targets.
+ *
+ * Implementation: trigram-Dice similarity (`src/similarity.ts`) against
+ * three candidate kinds — basenames, titles, and aliases — across the whole
+ * vault. The candidate scoring uses a stable preference order:
+ *   1. higher similarity
+ *   2. shorter candidate string (less ambiguous match)
+ *   3. lexicographic
+ *
+ * Only suggestions at or above the configured threshold are kept; the top
+ * two are attached to each broken entry. Suggestions are also rolled up
+ * into a "leverage view" that ranks fixes by how many broken occurrences
+ * they would close — usually a single alias addition closes dozens of
+ * links at once.
+ */
+
+import { similarity } from "../similarity.js";
+import type {
+  BrokenEntry,
+  LeverageFix,
+  ResolutionIndex,
+  Suggestion,
+  VaultFile,
+} from "./types.js";
+
+interface Candidate {
+  text: string;
+  kind: "basename" | "title" | "alias";
+  filePath: string;
+}
+
+function basename(relPath: string): string {
+  const slash = relPath.lastIndexOf("/");
+  const tail = slash >= 0 ? relPath.slice(slash + 1) : relPath;
+  return tail.replace(/\.md$/, "");
+}
+
+function buildCandidates(files: VaultFile[]): Candidate[] {
+  const out: Candidate[] = [];
+  for (const f of files) {
+    out.push({ text: basename(f.relPath), kind: "basename", filePath: f.relPath });
+    if (f.title) {
+      out.push({ text: f.title, kind: "title", filePath: f.relPath });
+    }
+    for (const alias of f.aliases) {
+      if (alias) out.push({ text: alias, kind: "alias", filePath: f.relPath });
+    }
+  }
+  return out;
+}
+
+/**
+ * Compute up to `topN` suggestions per broken entry, mutating each entry's
+ * `suggestions` array in place. Skips suggestion lookup entirely when
+ * `threshold` <= 0 — a documented opt-out for `--no-suggestions`.
+ */
+export function attachSuggestions(
+  broken: BrokenEntry[],
+  index: ResolutionIndex,
+  threshold: number,
+  topN: number = 2
+): void {
+  if (broken.length === 0 || threshold <= 0) return;
+
+  const candidates = buildCandidates(index.files);
+  if (candidates.length === 0) return;
+
+  for (const entry of broken) {
+    const scored: Array<{ cand: Candidate; sim: number }> = [];
+    for (const cand of candidates) {
+      const sim = similarity(entry.target, cand.text);
+      if (sim >= threshold) {
+        scored.push({ cand, sim });
+      }
+    }
+    scored.sort((a, b) => {
+      if (b.sim !== a.sim) return b.sim - a.sim;
+      if (a.cand.text.length !== b.cand.text.length) {
+        return a.cand.text.length - b.cand.text.length;
+      }
+      return a.cand.text.localeCompare(b.cand.text);
+    });
+
+    // Dedupe by file path so we don't show two suggestions pointing at the
+    // same file (basename + title of the same note typically score similar).
+    const seenPaths = new Set<string>();
+    const picked: Suggestion[] = [];
+    for (const { cand, sim } of scored) {
+      if (seenPaths.has(cand.filePath)) continue;
+      seenPaths.add(cand.filePath);
+      picked.push({
+        filePath: cand.filePath,
+        candidate: cand.text,
+        kind: cand.kind,
+        similarity: sim,
+        proposedAlias: entry.target,
+      });
+      if (picked.length >= topN) break;
+    }
+    entry.suggestions = picked;
+  }
+}
+
+/**
+ * Compute the "high-leverage fixes" view: aggregate broken entries by their
+ * top suggestion's file path and sum the broken counts. The result is the
+ * single sentence "adding alias X to file Y closes N broken links",
+ * sorted by N descending.
+ */
+export function computeLeverageFixes(broken: BrokenEntry[]): LeverageFix[] {
+  const buckets = new Map<string, { closes: number; aliases: string[] }>();
+  for (const entry of broken) {
+    const top = entry.suggestions[0];
+    if (!top) continue;
+    const bucket = buckets.get(top.filePath);
+    if (bucket) {
+      bucket.closes += entry.count;
+      if (!bucket.aliases.includes(entry.target)) {
+        bucket.aliases.push(entry.target);
+      }
+    } else {
+      buckets.set(top.filePath, { closes: entry.count, aliases: [entry.target] });
+    }
+  }
+  const fixes: LeverageFix[] = [];
+  for (const [filePath, { closes, aliases }] of buckets) {
+    fixes.push({
+      action: `add alias to ${filePath}`,
+      closes,
+      filePath,
+      aliases: [...aliases].sort(),
+    });
+  }
+  fixes.sort((a, b) => {
+    if (b.closes !== a.closes) return b.closes - a.closes;
+    return a.filePath.localeCompare(b.filePath);
+  });
+  return fixes;
+}

--- a/src/lint/types.ts
+++ b/src/lint/types.ts
@@ -1,0 +1,136 @@
+/**
+ * Public types for the vault-tasks lint engine.
+ *
+ * The engine is read-only by design: it walks the vault, builds an index of
+ * resolvable wikilink targets, and reports issues. It never mutates files.
+ */
+
+/** A single wikilink occurrence in a file. */
+export interface WikiLink {
+  /** Resolution key — alias and anchor stripped. */
+  target: string;
+  /** Vault-relative source file. */
+  source: string;
+  /** 1-based line number. */
+  line: number;
+}
+
+/** A file as seen by the linter. */
+export interface VaultFile {
+  /** Vault-relative path including .md extension. */
+  relPath: string;
+  /** Absolute path on disk. */
+  absPath: string;
+  /** title: from frontmatter, or null. */
+  title: string | null;
+  /** aliases: from frontmatter, normalised to a string array. */
+  aliases: string[];
+  /** Whether the file has any frontmatter block at all. */
+  hasFrontmatter: boolean;
+  /** Whether `tags:` appears as a frontmatter key (any value). */
+  hasTagsField: boolean;
+  /** Body text (post-frontmatter). */
+  body: string;
+  /** Full text including frontmatter, normalised to LF. */
+  text: string;
+  /**
+   * Per-file lint opt-outs read from frontmatter — flat keys to keep the
+   * minimal YAML parser sufficient. Setting any of these to a truthy value
+   * excludes the file from the corresponding check.
+   */
+  lintOpts: {
+    orphanOk: boolean;
+    staleOk: boolean;
+    driftOk: boolean;
+  };
+}
+
+/** Index used for resolving wikilink targets. */
+export interface ResolutionIndex {
+  /** Normalised key → list of vault-relative paths registered under that key. */
+  exact: Map<string, string[]>;
+  /** Normalised multi-component path-tail key → list of paths. */
+  tail: Map<string, string[]>;
+  /** All known files, in walk order. */
+  files: VaultFile[];
+  /** Lookup: vault-relative path → VaultFile. */
+  byPath: Map<string, VaultFile>;
+  /** Collisions: normalised key → distinct paths sharing that key. */
+  collisions: Map<string, string[]>;
+}
+
+/** A "did you mean?" suggestion for a broken wikilink target. */
+export interface Suggestion {
+  /** Vault-relative path of the suggested file. */
+  filePath: string;
+  /** The candidate string that matched (a basename, title, or alias). */
+  candidate: string;
+  /** What kind of candidate matched. */
+  kind: "basename" | "title" | "alias";
+  /** Trigram similarity, 0..1. */
+  similarity: number;
+  /**
+   * The proposed alias to add to filePath's frontmatter to close all
+   * occurrences of the broken target. Always equal to the broken target.
+   */
+  proposedAlias: string;
+}
+
+/** Aggregated entry for a single broken target. */
+export interface BrokenEntry {
+  target: string;
+  count: number;
+  locations: Array<{ source: string; line: number }>;
+  suggestions: Suggestion[];
+}
+
+/** A "high-leverage fix" — applying it would close many broken links at once. */
+export interface LeverageFix {
+  /** Action description, e.g. "add alias to 10-areas/foo/CONTEXT.md". */
+  action: string;
+  /** Number of broken links this fix would resolve. */
+  closes: number;
+  /** Vault-relative file path the fix would mutate. */
+  filePath: string;
+  /** Aliases to add (or filename to create). */
+  aliases: string[];
+}
+
+/** Single drift finding. */
+export interface DriftEntry {
+  filePath: string;
+  issues: string[];
+}
+
+/** Full lint report. */
+export interface LintReport {
+  broken: BrokenEntry[];
+  orphans: string[];
+  stale: string[];
+  drift: DriftEntry[];
+  leverageFixes: LeverageFix[];
+  warnings: string[];
+  /** Counts for the SUMMARY line. */
+  summary: {
+    broken: number;
+    orphans: number;
+    stale: number;
+    drift: number;
+  };
+  /** True if the report has any issues. */
+  hasIssues: boolean;
+}
+
+/** Runtime options for a lint run. */
+export interface LintOptions {
+  /** Restrict to files under this vault-relative subdir. */
+  scope?: string;
+  /** Run only this check. */
+  only?: "broken" | "orphans" | "stale" | "drift";
+  /** Skip the suggestion engine (faster). */
+  noSuggestions?: boolean;
+  /** Report warnings sink (defaults to console.error). */
+  onWarn?: (msg: string) => void;
+}
+
+export type CheckName = "broken" | "orphans" | "stale" | "drift";

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -321,6 +321,58 @@ describe("CLI error handling", () => {
     assert.equal(meta["status"], "in-progress");
     assert.equal(meta["priority"], "high");
   });
+
+  it("lint exits 0 on a clean vault and 1 with broken links", () => {
+    const clean = run(["lint"], dir);
+    assert.equal(clean.exitCode, 0);
+    assert.ok(clean.stdout.includes("SUMMARY: broken:0"));
+
+    writeFileSync(join(dir, "doc.md"), "[[ghost]]\n", "utf-8");
+    const dirty = run(["lint"], dir);
+    assert.equal(dirty.exitCode, 1);
+    assert.ok(dirty.stdout.includes("SUMMARY: broken:1"));
+  });
+
+  it("lint --quiet prints only the summary line", () => {
+    writeFileSync(join(dir, "doc.md"), "[[ghost]]\n", "utf-8");
+    const result = run(["lint", "--quiet"], dir);
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.stdout.trim(), "SUMMARY: broken:1 orphans:0 stale:0 drift:0");
+  });
+
+  it("lint --json emits valid JSON with full report", () => {
+    writeFileSync(join(dir, "doc.md"), "[[ghost]]\n", "utf-8");
+    const result = run(["lint", "--json"], dir);
+    assert.equal(result.exitCode, 1);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.summary.broken, 1);
+    assert.equal(parsed.broken[0].target, "ghost");
+    assert.equal(parsed.hasIssues, true);
+  });
+
+  it("lint --only without value exits 2 with usage error", () => {
+    const result = run(["lint", "--only"], dir);
+    assert.equal(result.exitCode, 2);
+    assert.ok(result.stderr.includes("--only requires a value"));
+  });
+
+  it("lint --only with invalid value exits 2", () => {
+    const result = run(["lint", "--only", "bogus"], dir);
+    assert.equal(result.exitCode, 2);
+    assert.ok(result.stderr.includes("--only must be one of"));
+  });
+
+  it("lint --scope without value exits 2", () => {
+    const result = run(["lint", "--scope"], dir);
+    assert.equal(result.exitCode, 2);
+    assert.ok(result.stderr.includes("--scope requires a value"));
+  });
+
+  it("lint --scope with .. is rejected", () => {
+    const result = run(["lint", "--scope", "../escape"], dir);
+    assert.equal(result.exitCode, 2);
+    assert.ok(result.stderr.includes("must be inside the vault"));
+  });
 });
 
 describe("CLI with ULID strategy", () => {

--- a/src/tests/counter.test.ts
+++ b/src/tests/counter.test.ts
@@ -27,7 +27,7 @@ function makeConfig(dir: string, strategy: Config["idStrategy"] = "sequential"):
     dedupeScanLimit: 500,
     project: { name: "", qualityCommand: "", testCommand: "", standardTags: [] },
     lint: {
-      referenceDir: "references",
+      referenceDir: join(dir, "references"),
       referenceExclude: [],
       templateSourceDirs: [],
       templateSourceFiles: [],

--- a/src/tests/counter.test.ts
+++ b/src/tests/counter.test.ts
@@ -26,6 +26,22 @@ function makeConfig(dir: string, strategy: Config["idStrategy"] = "sequential"):
     dedupeThreshold: 0.5,
     dedupeScanLimit: 500,
     project: { name: "", qualityCommand: "", testCommand: "", standardTags: [] },
+    lint: {
+      referenceDir: "references",
+      referenceExclude: [],
+      templateSourceDirs: [],
+      templateSourceFiles: [],
+      templatePatterns: [],
+      skipDirs: [".git", "node_modules"],
+      evergreenConventions: {
+        requireFrontmatter: true,
+        requireTitleField: true,
+        requireTagsField: true,
+        requireRelatedSection: true,
+        requireBodyWikilink: true,
+      },
+      suggestionThreshold: 0.6,
+    },
   };
 }
 

--- a/src/tests/lint.test.ts
+++ b/src/tests/lint.test.ts
@@ -9,7 +9,12 @@ import { buildIndex, normKey, resolveTarget, stripTargetSuffixes } from "../lint
 import { collectWikilinks, isTemplatePlaceholder, readVaultFiles } from "../lint/collect.js";
 import { findBrokenLinks } from "../lint/checks/broken.js";
 import { attachSuggestions, computeLeverageFixes } from "../lint/suggest.js";
-import type { BrokenEntry } from "../lint/types.js";
+import {
+  formatHumanReport,
+  formatJsonReport,
+  formatSummaryLine,
+} from "../lint/report.js";
+import type { BrokenEntry, LintReport } from "../lint/types.js";
 
 function makeConfig(dir: string, overrides: Partial<Config["lint"]> = {}): Config {
   return {
@@ -32,7 +37,7 @@ function makeConfig(dir: string, overrides: Partial<Config["lint"]> = {}): Confi
     dedupeScanLimit: 500,
     project: { name: "", qualityCommand: "", testCommand: "", standardTags: [] },
     lint: {
-      referenceDir: "40-references",
+      referenceDir: join(dir, "40-references"),
       referenceExclude: ["tweets/"],
       templateSourceDirs: [".claude/skills/", ".claude/rules/"],
       templateSourceFiles: ["CLAUDE.md"],
@@ -376,10 +381,22 @@ describe("lintVault", () => {
     const cfg = makeConfig(dir);
     const report = lintVault(cfg);
 
-    assert.ok(report.summary.broken >= 1, "expected at least one broken link");
-    assert.ok(report.summary.orphans >= 1, "expected at least one orphan");
-    assert.ok(report.summary.stale >= 1, "expected at least one stale reference");
-    assert.ok(report.summary.drift >= 1, "expected at least one drift");
+    // Exact counts — the fixture is deterministic.
+    assert.deepEqual(report.summary, {
+      broken: 1,
+      orphans: 1,
+      stale: 1,
+      drift: 1,
+    });
+    assert.equal(report.broken[0].target, "ghost");
+    assert.equal(report.broken[0].count, 1);
+    assert.deepEqual(report.orphans, ["30-evergreen/messy.md"]);
+    assert.deepEqual(report.stale, ["40-references/abandoned.md"]);
+    assert.equal(report.drift[0].filePath, "30-evergreen/messy.md");
+    assert.deepEqual(
+      report.drift[0].issues,
+      ["no frontmatter", "no wikilinks in body", "no ## Related section"]
+    );
     assert.equal(report.hasIssues, true);
   });
 
@@ -388,11 +405,13 @@ describe("lintVault", () => {
     write(dir, "j.md", "[[ghost]]");
     const cfg = makeConfig(dir);
     const onlyBroken = lintVault(cfg, { only: "broken" });
-    assert.ok(onlyBroken.summary.broken >= 1);
+    assert.equal(onlyBroken.summary.broken, 1);
+    assert.equal(onlyBroken.broken[0].target, "ghost");
     assert.equal(onlyBroken.summary.drift, 0);
     const onlyDrift = lintVault(cfg, { only: "drift" });
     assert.equal(onlyDrift.summary.broken, 0);
-    assert.ok(onlyDrift.summary.drift >= 1);
+    assert.equal(onlyDrift.summary.drift, 1);
+    assert.equal(onlyDrift.drift[0].filePath, "30-evergreen/messy.md");
   });
 
   it("respects per-file lint_orphan_ok opt-out", () => {
@@ -434,5 +453,242 @@ describe("lintVault", () => {
     const report = lintVault(cfg, { only: "broken" });
     assert.equal(report.summary.broken, 1);
     assert.equal(report.broken[0].target, "ghost");
+  });
+
+  it("forwards warnings to onWarn AND retains them in the report", () => {
+    write(dir, "Foo Bar.md", "---\ntitle: Foo Bar\n---\nBody");
+    write(dir, "foo-bar.md", "Body");
+    const seen: string[] = [];
+    const cfg = makeConfig(dir);
+    const report = lintVault(cfg, { onWarn: (m) => seen.push(m) });
+    assert.ok(seen.length > 0, "onWarn callback should fire");
+    assert.deepEqual(report.warnings, seen);
+  });
+});
+
+describe("report formatters", () => {
+  function makeReport(overrides: Partial<LintReport> = {}): LintReport {
+    return {
+      broken: [],
+      orphans: [],
+      stale: [],
+      drift: [],
+      leverageFixes: [],
+      warnings: [],
+      summary: { broken: 0, orphans: 0, stale: 0, drift: 0 },
+      hasIssues: false,
+      ...overrides,
+    };
+  }
+
+  it("formatSummaryLine produces the exact log-appendable string", () => {
+    const r = makeReport({ summary: { broken: 3, orphans: 1, stale: 0, drift: 2 } });
+    assert.equal(formatSummaryLine(r), "SUMMARY: broken:3 orphans:1 stale:0 drift:2");
+  });
+
+  it("formatSummaryLine on a clean report", () => {
+    assert.equal(formatSummaryLine(makeReport()), "SUMMARY: broken:0 orphans:0 stale:0 drift:0");
+  });
+
+  it("formatJsonReport round-trips through JSON.parse", () => {
+    const r = makeReport({
+      broken: [
+        {
+          target: "ghost",
+          count: 2,
+          locations: [
+            { source: "a.md", line: 1 },
+            { source: "b.md", line: 5 },
+          ],
+          suggestions: [
+            {
+              filePath: "ghost-real.md",
+              candidate: "ghost-real",
+              kind: "basename",
+              similarity: 0.85,
+              proposedAlias: "ghost",
+            },
+          ],
+        },
+      ],
+      orphans: ["evergreen/lonely.md"],
+      summary: { broken: 1, orphans: 1, stale: 0, drift: 0 },
+      hasIssues: true,
+    });
+    const json = formatJsonReport(r);
+    const parsed = JSON.parse(json);
+    assert.equal(parsed.summary.broken, 1);
+    assert.equal(parsed.summary.orphans, 1);
+    assert.equal(parsed.broken[0].target, "ghost");
+    assert.equal(parsed.broken[0].count, 2);
+    assert.equal(parsed.broken[0].suggestions[0].filePath, "ghost-real.md");
+    assert.deepEqual(parsed.orphans, ["evergreen/lonely.md"]);
+    assert.equal(parsed.hasIssues, true);
+  });
+
+  it("formatHumanReport renders all sections with counts", () => {
+    const r = makeReport({
+      broken: [
+        {
+          target: "ghost",
+          count: 3,
+          locations: [
+            { source: "a.md", line: 1 },
+            { source: "b.md", line: 2 },
+            { source: "c.md", line: 3 },
+          ],
+          suggestions: [
+            {
+              filePath: "ghost-real.md",
+              candidate: "ghost-real",
+              kind: "basename",
+              similarity: 0.85,
+              proposedAlias: "ghost",
+            },
+          ],
+        },
+      ],
+      orphans: ["30-evergreen/lonely.md"],
+      stale: ["40-references/abandoned.md"],
+      drift: [{ filePath: "30-evergreen/messy.md", issues: ["no frontmatter"] }],
+      leverageFixes: [
+        {
+          action: "add alias to ghost-real.md",
+          closes: 3,
+          filePath: "ghost-real.md",
+          aliases: ["ghost"],
+        },
+      ],
+      warnings: ["2 files share normalised key 'foo': a.md, b.md"],
+      summary: { broken: 1, orphans: 1, stale: 1, drift: 1 },
+      hasIssues: true,
+    });
+    const out = formatHumanReport(r);
+
+    assert.ok(out.includes("=== WARNINGS (1) ==="));
+    assert.ok(out.includes("share normalised key"));
+    assert.ok(out.includes("=== HIGH-LEVERAGE FIXES (1) ==="));
+    assert.ok(out.includes("add alias to ghost-real.md"));
+    assert.ok(out.includes("closes 3 broken links"));
+    assert.ok(out.includes("=== BROKEN WIKILINKS (1) ==="));
+    assert.ok(out.includes("[[ghost]]  (3 occurrences)"));
+    assert.ok(out.includes("suggest: ghost-real.md"));
+    assert.ok(out.includes("a.md:1"));
+    assert.ok(out.includes("=== ORPHAN EVERGREENS (1) ==="));
+    assert.ok(out.includes("30-evergreen/lonely.md"));
+    assert.ok(out.includes("=== STALE REFERENCES (1) ==="));
+    assert.ok(out.includes("40-references/abandoned.md"));
+    assert.ok(out.includes("=== CONVENTION DRIFT (1) ==="));
+    assert.ok(out.includes("30-evergreen/messy.md: no frontmatter"));
+    assert.ok(out.endsWith("SUMMARY: broken:1 orphans:1 stale:1 drift:1"));
+  });
+
+  it("formatHumanReport truncates locations beyond MAX with '+N more'", () => {
+    const locations = Array.from({ length: 7 }, (_, i) => ({
+      source: `f${i}.md`,
+      line: i + 1,
+    }));
+    const r = makeReport({
+      broken: [{ target: "ghost", count: 7, locations, suggestions: [] }],
+      summary: { broken: 1, orphans: 0, stale: 0, drift: 0 },
+      hasIssues: true,
+    });
+    const out = formatHumanReport(r);
+    // First 3 visible, then "+4 more"
+    assert.ok(out.includes("f0.md:1"));
+    assert.ok(out.includes("f1.md:2"));
+    assert.ok(out.includes("f2.md:3"));
+    assert.ok(out.includes("... +4 more"));
+    assert.ok(!out.includes("f6.md"));
+  });
+
+  it("formatHumanReport handles fully-clean report", () => {
+    const out = formatHumanReport(makeReport());
+    assert.ok(out.includes("=== BROKEN WIKILINKS (0) ==="));
+    assert.ok(out.includes("=== ORPHAN EVERGREENS (0) ==="));
+    assert.ok(out.includes("=== STALE REFERENCES (0) ==="));
+    assert.ok(out.includes("=== CONVENTION DRIFT (0) ==="));
+    assert.ok(!out.includes("WARNINGS"));
+    assert.ok(!out.includes("HIGH-LEVERAGE FIXES"));
+  });
+});
+
+describe("config validation for [lint]", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-lint-cfg-"));
+  });
+
+  it("rejects an invalid template_patterns regex with file context", async () => {
+    const { loadConfig } = await import("../config.js");
+    write(
+      dir,
+      ".vault-tasks.toml",
+      `[lint]\ntemplate_patterns = ["valid", "[unclosed"]\n`
+    );
+    assert.throws(
+      () => loadConfig(dir),
+      /template_patterns\[1\]:.*"\[unclosed"/
+    );
+  });
+
+  it("rejects suggestion_threshold outside 0..1", async () => {
+    const { loadConfig } = await import("../config.js");
+    write(dir, ".vault-tasks.toml", `[lint]\nsuggestion_threshold = 2\n`);
+    assert.throws(() => loadConfig(dir), /suggestion_threshold/);
+  });
+
+  it("loadConfig returns absolute referenceDir", async () => {
+    const { loadConfig } = await import("../config.js");
+    write(dir, ".vault-tasks.toml", `[lint]\nreference_dir = "my-refs"\n`);
+    const cfg = loadConfig(dir);
+    assert.ok(
+      cfg.lint.referenceDir.startsWith(dir),
+      `expected absolute path under ${dir}, got ${cfg.lint.referenceDir}`
+    );
+  });
+
+  it("loadConfig returns absolute referenceDir even with no config file", async () => {
+    const { loadConfig } = await import("../config.js");
+    const cfg = loadConfig(dir);
+    assert.ok(
+      cfg.lint.referenceDir.startsWith(dir),
+      `expected absolute path under ${dir}, got ${cfg.lint.referenceDir}`
+    );
+  });
+});
+
+describe("walkMarkdown (security)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-lint-walk-"));
+  });
+
+  it("does not follow directory symlinks (read only what's inside the vault)", async () => {
+    const { symlinkSync, mkdirSync } = await import("node:fs");
+    // External directory containing a markdown file the lint must NOT see.
+    const outside = mkdtempSync(join(tmpdir(), "vt-outside-"));
+    write(outside, "secret.md", "[[exfiltrate]]");
+    // Symlink inside the vault pointing at the external dir.
+    mkdirSync(dir, { recursive: true });
+    try {
+      symlinkSync(outside, join(dir, "linked"));
+    } catch (err) {
+      // Some CI environments disable symlink creation. Skip rather than fail.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EPERM" || code === "EACCES") return;
+      throw err;
+    }
+    write(dir, "real.md", "real body");
+    const cfg = makeConfig(dir);
+    const report = lintVault(cfg);
+    // No broken-link findings should be sourced from `linked/secret.md`.
+    const sources = report.broken.flatMap((b) => b.locations.map((l) => l.source));
+    for (const s of sources) {
+      assert.ok(
+        !s.includes("linked/"),
+        `walker should not have descended into the symlinked dir; saw: ${s}`
+      );
+    }
   });
 });

--- a/src/tests/lint.test.ts
+++ b/src/tests/lint.test.ts
@@ -1,0 +1,438 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Config } from "../config.js";
+import { lintVault } from "../lint/index.js";
+import { buildIndex, normKey, resolveTarget, stripTargetSuffixes } from "../lint/resolve.js";
+import { collectWikilinks, isTemplatePlaceholder, readVaultFiles } from "../lint/collect.js";
+import { findBrokenLinks } from "../lint/checks/broken.js";
+import { attachSuggestions, computeLeverageFixes } from "../lint/suggest.js";
+import type { BrokenEntry } from "../lint/types.js";
+
+function makeConfig(dir: string, overrides: Partial<Config["lint"]> = {}): Config {
+  return {
+    vaultRoot: dir,
+    backlogDir: join(dir, "backlog"),
+    archiveDir: join(dir, "backlog", "archive"),
+    journalDir: join(dir, "journal"),
+    projectsDir: join(dir, "projects"),
+    evergreenDir: join(dir, "30-evergreen"),
+    statuses: ["open", "in-progress", "done", "wont-do"],
+    priorities: ["high", "medium", "low"],
+    defaultPriority: "medium",
+    defaultStatus: "open",
+    archiveStatuses: ["done", "wont-do"],
+    autoArchive: true,
+    idStrategy: "sequential",
+    padWidth: 4,
+    slugMaxLength: 60,
+    dedupeThreshold: 0.5,
+    dedupeScanLimit: 500,
+    project: { name: "", qualityCommand: "", testCommand: "", standardTags: [] },
+    lint: {
+      referenceDir: "40-references",
+      referenceExclude: ["tweets/"],
+      templateSourceDirs: [".claude/skills/", ".claude/rules/"],
+      templateSourceFiles: ["CLAUDE.md"],
+      templatePatterns: ["^YYYY", "^<", "^wikilinks?$", "^target$", "^note-name$"],
+      skipDirs: [".git", "node_modules"],
+      evergreenConventions: {
+        requireFrontmatter: true,
+        requireTitleField: true,
+        requireTagsField: true,
+        requireRelatedSection: true,
+        requireBodyWikilink: true,
+      },
+      suggestionThreshold: 0.6,
+      ...overrides,
+    },
+  };
+}
+
+function write(dir: string, relPath: string, content: string): void {
+  const abs = join(dir, relPath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content, "utf-8");
+}
+
+describe("normKey", () => {
+  it("strips whitespace, hyphens, underscores, colons", () => {
+    assert.equal(normKey("Bioform AI"), "bioformai");
+    assert.equal(normKey("bioform-ai"), "bioformai");
+    assert.equal(normKey("bioform_ai"), "bioformai");
+    assert.equal(normKey("Bioform: AI"), "bioformai");
+    assert.equal(normKey("BIOFORM AI"), "bioformai");
+  });
+
+  it("preserves slashes", () => {
+    assert.equal(normKey("foo/bar"), "foo/bar");
+    assert.equal(normKey("10-areas/parenting/CONTEXT"), "10areas/parenting/context");
+  });
+});
+
+describe("stripTargetSuffixes", () => {
+  it("strips alias", () => {
+    assert.equal(stripTargetSuffixes("foo|bar"), "foo");
+  });
+  it("strips anchor", () => {
+    assert.equal(stripTargetSuffixes("foo#section"), "foo");
+  });
+  it("strips alias when both present", () => {
+    assert.equal(stripTargetSuffixes("foo#section|bar"), "foo");
+  });
+  it("trims whitespace", () => {
+    assert.equal(stripTargetSuffixes("  foo  "), "foo");
+  });
+});
+
+describe("buildIndex + resolveTarget", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-lint-resolve-"));
+  });
+
+  it("resolves filename stem case-insensitively", () => {
+    write(dir, "case-insensitive.md", "Body");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const idx = buildIndex(files);
+    assert.equal(resolveTarget("CASE-INSENSITIVE", idx), "case-insensitive.md");
+    assert.equal(resolveTarget("case insensitive", idx), "case-insensitive.md");
+    assert.equal(resolveTarget("Case Insensitive", idx), "case-insensitive.md");
+  });
+
+  it("resolves against title: frontmatter", () => {
+    write(
+      dir,
+      "title-fm.md",
+      "---\ntitle: \"Some Title\"\n---\nBody"
+    );
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const idx = buildIndex(files);
+    assert.equal(resolveTarget("Some Title", idx), "title-fm.md");
+    assert.equal(resolveTarget("some-title", idx), "title-fm.md");
+  });
+
+  it("resolves against aliases", () => {
+    write(
+      dir,
+      "canonical.md",
+      "---\ntitle: Canonical\naliases: [bioform-ai, BioForm]\n---\nBody"
+    );
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const idx = buildIndex(files);
+    assert.equal(resolveTarget("bioform ai", idx), "canonical.md");
+    assert.equal(resolveTarget("BioForm", idx), "canonical.md");
+  });
+
+  it("resolves path-form targets", () => {
+    write(dir, "folder/path-form.md", "Body");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const idx = buildIndex(files);
+    assert.equal(resolveTarget("folder/path-form", idx), "folder/path-form.md");
+    assert.equal(resolveTarget("folder/Path-Form", idx), "folder/path-form.md");
+  });
+
+  it("resolves partial-path tail when unique", () => {
+    write(dir, "10-areas/parenting/CONTEXT.md", "Body");
+    write(dir, "10-areas/investing/CONTEXT.md", "Body");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const idx = buildIndex(files);
+    assert.equal(
+      resolveTarget("parenting/CONTEXT", idx),
+      "10-areas/parenting/CONTEXT.md"
+    );
+    // Just "CONTEXT" is ambiguous (two files share the basename) — must
+    // not silently pick one.
+    assert.equal(resolveTarget("CONTEXT", idx), null);
+  });
+
+  it("strips |alias and #anchor before resolving", () => {
+    write(dir, "target.md", "Body");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const idx = buildIndex(files);
+    assert.equal(resolveTarget("target|display", idx), "target.md");
+    assert.equal(resolveTarget("target#section", idx), "target.md");
+    assert.equal(resolveTarget("target#section|display", idx), "target.md");
+  });
+
+  it("flags collisions on the index", () => {
+    write(dir, "Foo Bar.md", "---\ntitle: Foo Bar\n---\nBody");
+    write(dir, "foo-bar.md", "---\ntitle: foo bar\n---\nBody");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const idx = buildIndex(files);
+    const collidedKey = idx.collisions.get("foobar");
+    assert.ok(collidedKey, "expected collision under 'foobar'");
+    assert.equal(collidedKey!.length, 2);
+  });
+});
+
+describe("collectWikilinks", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-lint-collect-"));
+  });
+
+  it("skips fenced code blocks", () => {
+    write(
+      dir,
+      "doc.md",
+      "Real [[real-link]]\n\n```\nExample [[fake-link]]\n```\n\nAnother [[another]]"
+    );
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const links = collectWikilinks(files, [], [], []);
+    const targets = links.map((l) => l.target);
+    assert.deepEqual(targets, ["real-link", "another"]);
+  });
+
+  it("skips inline code spans", () => {
+    write(dir, "doc.md", "Use `[[example]]` to mean the wikilink form. Real: [[actual]]");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const links = collectWikilinks(files, [], [], []);
+    const targets = links.map((l) => l.target);
+    assert.deepEqual(targets, ["actual"]);
+  });
+
+  it("skips template placeholders inside template-source directories", () => {
+    write(dir, ".claude/skills/foo/SKILL.md", "Use [[YYYY-MM-DD]] and [[<filename>]]");
+    write(dir, "real.md", "[[YYYY-MM-DD]] is a real link here");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const links = collectWikilinks(
+      files,
+      [".claude/skills/", ".claude/rules/"],
+      ["CLAUDE.md"],
+      ["^YYYY", "^<"]
+    );
+    // Inside template source: filtered.
+    const fromSkill = links.filter((l) => l.source.startsWith(".claude/skills"));
+    assert.equal(fromSkill.length, 0);
+    // Outside: kept.
+    const fromReal = links.filter((l) => l.source === "real.md");
+    assert.equal(fromReal.length, 1);
+    assert.equal(fromReal[0].target, "YYYY-MM-DD");
+  });
+
+  it("strips alias and anchor on collected target", () => {
+    write(dir, "doc.md", "[[foo|display]] [[bar#section]]");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const links = collectWikilinks(files, [], [], []);
+    const targets = links.map((l) => l.target);
+    assert.deepEqual(targets, ["foo", "bar"]);
+  });
+
+  it("isTemplatePlaceholder is exact for template files", () => {
+    const compiled = [/^YYYY/, /^<filename>$/];
+    assert.equal(
+      isTemplatePlaceholder("YYYY-MM-DD", "CLAUDE.md", [], ["CLAUDE.md"], compiled),
+      true
+    );
+    assert.equal(
+      isTemplatePlaceholder("real-name", "CLAUDE.md", [], ["CLAUDE.md"], compiled),
+      false
+    );
+    assert.equal(
+      isTemplatePlaceholder("YYYY-MM-DD", "real.md", [], ["CLAUDE.md"], compiled),
+      false
+    );
+  });
+});
+
+describe("findBrokenLinks", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-lint-broken-"));
+  });
+
+  it("aggregates by target and sorts by frequency desc", () => {
+    write(dir, "exists.md", "Body");
+    write(dir, "a.md", "[[missing]]");
+    write(dir, "b.md", "[[missing]]");
+    write(dir, "c.md", "[[missing]]");
+    write(dir, "d.md", "[[other-missing]]");
+    write(dir, "e.md", "[[exists]]");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const links = collectWikilinks(files, [], [], []);
+    const idx = buildIndex(files);
+    const broken = findBrokenLinks(links, idx);
+    assert.equal(broken.length, 2);
+    assert.equal(broken[0].target, "missing");
+    assert.equal(broken[0].count, 3);
+    assert.equal(broken[1].target, "other-missing");
+    assert.equal(broken[1].count, 1);
+  });
+});
+
+describe("attachSuggestions", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-lint-suggest-"));
+  });
+
+  it("suggests files based on basename similarity", () => {
+    write(dir, "bioform-ai.md", "---\ntitle: BioForm AI\n---\nBody");
+    write(dir, "broken.md", "[[bioform ai]]");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const links = collectWikilinks(files, [], [], []);
+    const idx = buildIndex(files);
+    // Nothing's broken because resolution succeeds via title match.
+    // Test the suggestion engine directly with a forced broken entry.
+    const broken: BrokenEntry[] = [
+      {
+        target: "bioformai-different",
+        count: 1,
+        locations: [{ source: "broken.md", line: 1 }],
+        suggestions: [],
+      },
+    ];
+    attachSuggestions(broken, idx, 0.5);
+    assert.ok(broken[0].suggestions.length > 0);
+    const top = broken[0].suggestions[0];
+    assert.equal(top.filePath, "bioform-ai.md");
+    assert.ok(top.similarity >= 0.5);
+  });
+
+  it("respects threshold cutoff", () => {
+    write(dir, "alpha-beta.md", "Body");
+    const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
+    const idx = buildIndex(files);
+    const broken: BrokenEntry[] = [
+      {
+        target: "completely-unrelated-target-xyzzy",
+        count: 1,
+        locations: [{ source: "x.md", line: 1 }],
+        suggestions: [],
+      },
+    ];
+    attachSuggestions(broken, idx, 0.6);
+    assert.equal(broken[0].suggestions.length, 0);
+  });
+
+  it("computes leverage fixes summed across broken targets", () => {
+    write(dir, "canonical.md", "---\ntitle: Canonical\n---\nBody");
+    const idx = buildIndex(
+      readVaultFiles(dir, [".git", "node_modules"], () => {})
+    );
+    const broken: BrokenEntry[] = [
+      {
+        target: "canonicaal", // typo, similar to "canonical"
+        count: 5,
+        locations: [],
+        suggestions: [],
+      },
+      {
+        target: "canonacal", // another typo
+        count: 3,
+        locations: [],
+        suggestions: [],
+      },
+    ];
+    attachSuggestions(broken, idx, 0.5);
+    const fixes = computeLeverageFixes(broken);
+    assert.equal(fixes.length, 1);
+    assert.equal(fixes[0].filePath, "canonical.md");
+    assert.equal(fixes[0].closes, 8);
+    assert.equal(fixes[0].aliases.length, 2);
+  });
+});
+
+describe("lintVault", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vt-lint-e2e-"));
+  });
+
+  it("reports zero issues on a clean vault", () => {
+    write(
+      dir,
+      "30-evergreen/note.md",
+      "---\ntitle: Note\ntags: [foo]\n---\n# Note\n\n[[other]]\n\n## Related\n\n[[other]]"
+    );
+    write(dir, "30-evergreen/other.md", "---\ntitle: Other\ntags: [foo]\n---\n# Other\n\n[[note]]\n\n## Related\n\n[[note]]");
+    const cfg = makeConfig(dir);
+    const report = lintVault(cfg);
+    assert.equal(report.summary.broken, 0);
+    assert.equal(report.summary.orphans, 0);
+    assert.equal(report.summary.drift, 0);
+    assert.equal(report.hasIssues, false);
+  });
+
+  it("detects broken, orphan, stale, and drift in one pass", () => {
+    // Broken: one file links to [[ghost]] which doesn't exist
+    write(dir, "01-journal/2026.md", "[[ghost]]");
+    // Orphan: an evergreen with no incoming links
+    write(
+      dir,
+      "30-evergreen/lonely.md",
+      "---\ntitle: Lonely\ntags: [x]\n---\n# Lonely\n\n[[somewhere]]\n\n## Related"
+    );
+    // Drift: an evergreen missing all conventions
+    write(dir, "30-evergreen/messy.md", "Just text, no frontmatter or headings");
+    // Stale: a reference with no incoming links
+    write(dir, "40-references/abandoned.md", "Body");
+    // Resolution target for [[somewhere]]
+    write(dir, "30-evergreen/somewhere.md", "---\ntitle: Somewhere\ntags: [x]\n---\n# Somewhere\n\n[[lonely]]\n\n## Related");
+
+    const cfg = makeConfig(dir);
+    const report = lintVault(cfg);
+
+    assert.ok(report.summary.broken >= 1, "expected at least one broken link");
+    assert.ok(report.summary.orphans >= 1, "expected at least one orphan");
+    assert.ok(report.summary.stale >= 1, "expected at least one stale reference");
+    assert.ok(report.summary.drift >= 1, "expected at least one drift");
+    assert.equal(report.hasIssues, true);
+  });
+
+  it("respects --only filter", () => {
+    write(dir, "30-evergreen/messy.md", "no convention");
+    write(dir, "j.md", "[[ghost]]");
+    const cfg = makeConfig(dir);
+    const onlyBroken = lintVault(cfg, { only: "broken" });
+    assert.ok(onlyBroken.summary.broken >= 1);
+    assert.equal(onlyBroken.summary.drift, 0);
+    const onlyDrift = lintVault(cfg, { only: "drift" });
+    assert.equal(onlyDrift.summary.broken, 0);
+    assert.ok(onlyDrift.summary.drift >= 1);
+  });
+
+  it("respects per-file lint_orphan_ok opt-out", () => {
+    write(
+      dir,
+      "30-evergreen/inbox.md",
+      "---\ntitle: Inbox\ntags: [x]\nlint_orphan_ok: true\n---\n# Inbox\n\n[[noop]]\n\n## Related"
+    );
+    write(dir, "30-evergreen/noop.md", "---\ntitle: Noop\ntags: [x]\n---\n# Noop\n\n[[inbox]]\n\n## Related");
+    const cfg = makeConfig(dir);
+    const report = lintVault(cfg, { only: "orphans" });
+    assert.equal(report.summary.orphans, 0);
+  });
+
+  it("emits collision warnings", () => {
+    write(dir, "Foo Bar.md", "---\ntitle: Foo Bar\n---\nBody");
+    write(dir, "foo-bar.md", "Body");
+    const cfg = makeConfig(dir);
+    const report = lintVault(cfg);
+    assert.ok(
+      report.warnings.some((w) => w.includes("share normalised key")),
+      "expected a collision warning"
+    );
+  });
+
+  it("scopes to a subdir without breaking resolution", () => {
+    // [[shared]] lives outside the scope; it should still resolve so the
+    // link inside the scope is not falsely flagged as broken.
+    write(dir, "shared.md", "---\ntitle: Shared\n---\nBody");
+    write(dir, "30-evergreen/note.md", "---\ntitle: Note\ntags: [x]\n---\n# Note\n\n[[shared]]\n\n## Related");
+    const cfg = makeConfig(dir);
+    const report = lintVault(cfg, { scope: "30-evergreen" });
+    assert.equal(report.summary.broken, 0);
+  });
+
+  it("CRLF input does not break collection", () => {
+    write(dir, "doc.md", "Line one\r\n[[ghost]]\r\nLine three\r\n");
+    const cfg = makeConfig(dir);
+    const report = lintVault(cfg, { only: "broken" });
+    assert.equal(report.summary.broken, 1);
+    assert.equal(report.broken[0].target, "ghost");
+  });
+});

--- a/src/tests/store.test.ts
+++ b/src/tests/store.test.ts
@@ -27,7 +27,7 @@ function makeConfig(dir: string): Config {
     dedupeScanLimit: 500,
     project: { name: "", qualityCommand: "", testCommand: "", standardTags: [] },
     lint: {
-      referenceDir: "references",
+      referenceDir: join(dir, "references"),
       referenceExclude: [],
       templateSourceDirs: [],
       templateSourceFiles: [],

--- a/src/tests/store.test.ts
+++ b/src/tests/store.test.ts
@@ -26,6 +26,22 @@ function makeConfig(dir: string): Config {
     dedupeThreshold: 0.5,
     dedupeScanLimit: 500,
     project: { name: "", qualityCommand: "", testCommand: "", standardTags: [] },
+    lint: {
+      referenceDir: "references",
+      referenceExclude: [],
+      templateSourceDirs: [],
+      templateSourceFiles: [],
+      templatePatterns: [],
+      skipDirs: [".git", "node_modules"],
+      evergreenConventions: {
+        requireFrontmatter: true,
+        requireTitleField: true,
+        requireTagsField: true,
+        requireRelatedSection: true,
+        requireBodyWikilink: true,
+      },
+      suggestionThreshold: 0.6,
+    },
   };
 }
 

--- a/templates/skills/lint/SKILL.md
+++ b/templates/skills/lint/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: lint
+description: Audit the vault for orphan notes, broken wikilinks, missing
+  concept pages, convention drift, and potential contradictions. Read-only —
+  presents findings, never auto-edits. Use when the user says "lint the
+  vault", "health check", "find orphans", or "audit the notes".
+---
+
+# /lint
+
+The Maintain pillar of the Karpathy LLM-Wiki pattern. `vt lint` is the
+mechanical engine; this skill is the conversation layer that turns its
+output into a triage.
+
+## Steps
+
+1. Run the mechanical checks. The CLI does broken wikilinks, orphan
+   evergreens, stale references, and convention drift in one pass:
+   ```bash
+   vt lint
+   ```
+   The last line prints a `SUMMARY:` that feeds into step 5. Use
+   `vt lint --only broken` to iterate fast on a single check, or
+   `vt lint --scope 30-evergreen` to narrow the focus to a subtree.
+
+2. Qualitative checks the script does not do — do these by hand after
+   reading the script output:
+   - **Missing concept pages** — scan evergreens for bolded terms or
+     repeated capitalised phrases that appear in 3+ evergreens but have no
+     dedicated note. Suggest candidates.
+   - **Index and log health** — confirm `index.md` lists every evergreen
+     and area; confirm `log.md` has recent entries for recent commits.
+   - **Potential contradictions** — optionally, pick 2–3 clusters of
+     tightly linked evergreens and read them together; flag claims that
+     disagree or overlap awkwardly. Expensive; skip unless asked.
+   - **Tag-set drift** — the script checks for presence of `tags:`; it
+     does not check the standard set. Eyeball this against the canonical
+     tag set; flag any evergreen using a tag not in that set.
+
+3. Present findings as a single report grouped by category. Lead with the
+   `HIGH-LEVERAGE FIXES` section from the script output — these are the
+   single-action fixes that close many broken links at once. Then the
+   per-target broken-link detail, then orphans, stale, and drift. Add the
+   qualitative findings as a separate section. Use wikilinks so the user
+   can jump to sources. Do not edit anything.
+
+4. Offer next steps — `/expand` on concept candidates, opening specific
+   files for review, or a follow-up `/lint --scope <dir>` against a
+   specific subtree.
+
+5. Append a log entry with the summary line from the CLI:
+   ```
+   ## [YYYY-MM-DD] lint | broken:N orphans:N stale:N drift:N — <one-line note>
+   ```
+
+## How `vt lint` resolves wikilinks (why naive grep misses this)
+
+The CLI handles all of these; if you ever extend the checks by hand, do
+not regress on them:
+
+- **Case-insensitive and whitespace-agnostic.** `[[Abstract language enables
+  ideological projection]]` resolves to
+  `abstract-language-enables-ideological-projection.md`. Space, hyphen,
+  underscore, and colon are interchangeable; the lookup lowercases both
+  sides before comparing.
+- **Resolves against `title:` frontmatter and `aliases:`, not just the
+  filename.** Many evergreens use the Title-Case wikilink form because
+  that matches the note's title frontmatter field. A grep for
+  exact-filename matches will produce false positives in the hundreds.
+- **Path-form links resolve to that path.** `[[10-areas/investing/CONTEXT]]`
+  means the file at `10-areas/investing/CONTEXT.md`.
+- **Partial-path tails resolve by suffix match when unique.**
+  `[[parenting/CONTEXT]]` → `10-areas/parenting/CONTEXT.md`.
+- **`|alias` and `#anchor` suffixes are stripped before resolution.**
+  `[[foo|bar]]` resolves `foo`; `[[foo#heading]]` resolves `foo`.
+
+## Template placeholders to skip
+
+Skill/rule files and `CLAUDE.md` contain example wikilinks
+(`[[YYYY-MM-DD]]`, `[[<filename>]]`, `[[note-name]]`, `[[wikilink]]`,
+`[[target]]`, `[[0001-task-slug]]`, etc.) that are documentation, not real
+links. The CLI filters these via `[lint] template_source_dirs` and
+`template_patterns` in `.vault-tasks.toml`; if you extend the checks by
+hand, preserve the exclusion.
+
+## Per-file opt-outs
+
+A file can opt out of individual checks via flat frontmatter keys:
+
+```yaml
+---
+lint_orphan_ok: true   # don't flag this file as an orphan
+lint_stale_ok: true    # don't flag this file as a stale reference
+lint_drift_ok: true    # don't enforce evergreen conventions on this file
+---
+```
+
+Use sparingly — opt-outs are debt. They are most appropriate for
+intentionally-orphan inboxes, drafts, or imported notes that are not
+expected to fit the local conventions.
+
+## CLI flags
+
+```
+vt lint                          # full pass, human-readable output
+vt lint --only broken            # one check at a time during cleanup
+vt lint --scope 30-evergreen     # restrict to a subtree
+vt lint --json                   # machine-readable (CI, dashboards)
+vt lint --quiet                  # only the SUMMARY line
+vt lint --no-suggestions         # skip "did you mean?" (faster on big vaults)
+```
+
+Exit codes: `0` clean, `1` issues found, `2` configuration or I/O error.
+
+## Notes
+
+- **Read-only.** This skill never writes to notes. The only file it may
+  append to is `log.md`.
+- Present findings; let the user decide what to act on. Mirrors the style
+  of `/consolidate`.
+- Keep the human-report tight — one line per finding.
+- Default to a full lint. Accept narrowed scope ("just evergreens", "just
+  investments") by passing `--scope`.


### PR DESCRIPTION
## Summary

- Adds `vt lint` — a read-only audit of an Obsidian-style vault that detects broken wikilinks, orphan evergreens, stale references, and convention drift on evergreens. Completes the Maintain pillar of the Karpathy LLM-Wiki pattern.
- Ships the `/lint` skill template (auto-discovered by `vt install-skills`) and exports the full lint surface from the library API.
- Bumps to `v0.3.0` (additive feature, no breaking changes).

## What changed

- **`src/lint/`** — orchestrator + Obsidian-correct resolution. Case-insensitive, whitespace/hyphen/underscore/colon-agnostic; resolves against filename stem, full path stem, `title:`, and `aliases:`. Path-form (`[[10-areas/foo/CONTEXT]]`) and unique partial-path tails (`[[parenting/CONTEXT]]`) resolve via a precomputed tail index (O(1) per link, vs O(N) in the reference Python). `|alias` and `#anchor` stripped before resolution. Lookup collisions are warned to stderr instead of silently overwriting.
- **`src/lint/checks/{broken,orphans,stale,drift}.ts`** — the four checks. Broken aggregated and sorted by frequency descending. Orphans/stale share an inbound-link map built once. Drift conventions are individually configurable.
- **`src/lint/suggest.ts`** — trigram-Dice "did you mean?" against basenames, titles, and aliases. Suggestions roll up into a HIGH-LEVERAGE FIXES view that ranks fixes by how many broken occurrences they close.
- **`src/lint/report.ts`** — human + JSON formatters + the `SUMMARY:` line for log-appending.
- **`src/commands/lint.ts`** + `cli.ts` — flags `--only`, `--scope`, `--json`, `--quiet`, `--no-suggestions`. Exit codes: `0` clean, `1` issues, `2` config/I-O.
- **Config** — new `[lint]` and `[lint.evergreen_conventions]` TOML sections with sensible defaults. Per-file opt-outs via flat frontmatter keys (`lint_orphan_ok`, `lint_stale_ok`, `lint_drift_ok`).
- **Public API** exports `lintVault`, `buildIndex`, `resolveTarget`, the check functions, and the `LintReport`/`LintOptions`/`WikiLink`/`VaultFile` types for embedding.
- **`templates/skills/lint/SKILL.md`** — the Claude-side wrapper.
- **Tests** — 23 lint tests in `src/tests/lint.test.ts` covering normalisation, alias/anchor stripping, all six resolution rules, code-block / inline-code / template-placeholder filtering, broken aggregation, suggestion threshold, leverage rollup, end-to-end checks, scope, opt-outs, and CRLF.

## Why

The reference Python script that this ports has been validated against an unrelated 1100-file vault (28% of 912 wikilinks broken, with massive duplication on a few canonical targets). That validation surfaced the MUST-improve list: count-desc sort, similarity suggestions, leverage view, configurable folder conventions, O(1) tail-index, and collision warnings — all landed here.

Read-only by design: mutation belongs in `/expand`, `/consolidate`, or a future `vt fix`. No `--fix` flag in v1.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 249 tests pass (zero failures), including 23 new lint tests
- [x] End-to-end smoke against a fixture vault: all four checks fire correctly, exit code 1 on issues, 0 on clean
- [x] `--json` output is valid JSON with full report data; suggestions populated with similarity scores
- [x] `vt install-skills --list` shows `lint` alongside the existing skills
- [x] `vt --help` mentions `lint`
- [ ] Reviewer sanity-check on resolution rules (the spec section in `src/lint/resolve.ts`) — these are correctness invariants; regressions produce false positives in the hundreds

## Notes for reviewers

- The minimal TOML and YAML parsers limit us to single-line arrays and flat keys — that's why the per-file opt-outs are flat (`lint_orphan_ok: true`) instead of nested (`lint: { orphan: ok }`).
- `templatePatterns` defaults are baked into `config.ts` (`DEFAULT_LINT_TEMPLATE_PATTERNS`); users override via `[lint] template_patterns = [...]`.
- The orchestrator always builds the resolution index across the full vault, even when `--scope` narrows the checks. Scoping a check to a subtree should not falsely flag links whose target lives outside the subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)