### PR TITLE
feat(new): add --body and --body-file to set task body at creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vault-tasks",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vault-tasks",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "bin": {
         "vault-tasks": "dist/cli.js",
@@ -17,7 +17,7 @@
         "typescript": "^5.8.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@types/node": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -213,8 +213,6 @@ function main(): void {
         const bodyArg = args["body"];
         const bodyFileArg = args["body-file"];
 
-        // Reject missing values before mutex so the diagnostic points at the
-        // real mistake when the user typed `--body= --body-file=`.
         if (bodyArg === true || bodyArg === "") {
           console.error("Error: --body requires a value (a string, or '-' to read from stdin).");
           process.exitCode = 2;
@@ -254,8 +252,7 @@ function main(): void {
           }
         }
 
-        // Normalize CRLF→LF (Windows interop) and trailing newline so file
-        // output is consistent across input sources (inline / stdin / file).
+        // Normalize CRLF (Windows) and collapse trailing newlines to one.
         if (body !== undefined) {
           body = body.replace(/\r\n/g, "\n").replace(/\n*$/, "\n");
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "node:fs";
 import { loadConfig } from "./config.js";
 import { cmdArchive } from "./commands/archive.js";
 import { cmdDone } from "./commands/done.js";
@@ -71,6 +70,40 @@ const BOOLEAN_FLAGS = new Set([
   "no-suggestions",
 ]);
 
+// Flags that require a value. parseArgs throws an actionable error when one
+// of these is passed without a value (e.g. `vt new T --priority` followed by
+// EOL or another flag) so commands never receive a boolean for a string field.
+const VALUE_FLAGS = new Set([
+  "priority",
+  "tags",
+  "source",
+  "body",
+  "body-file",
+  "status",
+  "tag",
+  "days",
+  "only",
+  "scope",
+]);
+
+const VALUE_FLAG_HINTS: Record<string, string> = {
+  priority: "high, medium, or low",
+  tags: "comma-separated tag names",
+  source: "where this was noticed (e.g. [[2026-05-09]])",
+  body: "a string, or '-' to read from stdin",
+  "body-file": "a file path",
+  status: "open, in-progress, done, or wont-do",
+  tag: "a tag name",
+  days: "a positive integer",
+  only: "broken|orphans|stale|drift",
+  scope: "a directory",
+};
+
+function missingValueError(key: string): Error {
+  const hint = VALUE_FLAG_HINTS[key];
+  return new Error(`Flag --${key} requires a value${hint ? ` (${hint})` : ""}.`);
+}
+
 function isFlag(arg: string): boolean {
   if (arg.startsWith("--")) return true;
   if (arg.startsWith("-") && arg.length === 2 && /[a-zA-Z]/.test(arg[1])) return true;
@@ -112,6 +145,9 @@ function parseArgs(argv: string[]): { command: string; args: Record<string, stri
           );
         }
       } else {
+        if (VALUE_FLAGS.has(key) && rawValue === "") {
+          throw missingValueError(key);
+        }
         args[key] = rawValue;
       }
       i++;
@@ -128,6 +164,8 @@ function parseArgs(argv: string[]): { command: string; args: Record<string, stri
         if (next && !isFlag(next)) {
           args[key] = next;
           i += 2;
+        } else if (VALUE_FLAGS.has(key)) {
+          throw missingValueError(key);
         } else {
           args[key] = true;
           i++;
@@ -143,6 +181,8 @@ function parseArgs(argv: string[]): { command: string; args: Record<string, stri
         if (next && !isFlag(next)) {
           args[key] = next;
           i += 2;
+        } else if (VALUE_FLAGS.has(key)) {
+          throw missingValueError(key);
         } else {
           args[key] = true;
           i++;
@@ -172,7 +212,7 @@ function main(): void {
     ({ command, args, positional } = parseArgs(rawArgs));
   } catch (err) {
     console.error((err as Error).message);
-    process.exitCode = 1;
+    process.exitCode = 2;
     return;
   }
 
@@ -203,71 +243,23 @@ function main(): void {
 
   try {
     switch (command) {
-      case "new": {
+      case "new":
         if (!positional[0]) {
           console.error("Usage: vt new <title> [--priority P] [--tags t1,t2] [--source S] [--commit] [--body TEXT|--body-file PATH]");
           process.exitCode = 1;
           return;
         }
-
-        const bodyArg = args["body"];
-        const bodyFileArg = args["body-file"];
-
-        if (bodyArg === true || bodyArg === "") {
-          console.error("Error: --body requires a value (a string, or '-' to read from stdin).");
-          process.exitCode = 2;
-          return;
-        }
-        if (bodyFileArg === true || bodyFileArg === "") {
-          console.error("Error: --body-file requires a path.");
-          process.exitCode = 2;
-          return;
-        }
-        if (bodyArg !== undefined && bodyFileArg !== undefined) {
-          console.error("Error: --body and --body-file are mutually exclusive. Pass one or the other.");
-          process.exitCode = 2;
-          return;
-        }
-
-        let body: string | undefined;
-        if (typeof bodyArg === "string") {
-          if (bodyArg === "-") {
-            try {
-              body = readFileSync(0, "utf-8");
-            } catch (err) {
-              console.error(`Error: failed to read body from stdin: ${(err as Error).message}. Pipe content into the command, e.g. cat spec.md | vt new "..." --body -`);
-              process.exitCode = 1;
-              return;
-            }
-          } else {
-            body = bodyArg;
-          }
-        } else if (typeof bodyFileArg === "string") {
-          try {
-            body = readFileSync(bodyFileArg, "utf-8");
-          } catch (err) {
-            console.error(`Error: failed to read --body-file '${bodyFileArg}': ${(err as Error).message}`);
-            process.exitCode = 1;
-            return;
-          }
-        }
-
-        // Normalize CRLF (Windows) and collapse trailing newlines to one.
-        if (body !== undefined) {
-          body = body.replace(/\r\n/g, "\n").replace(/\n*$/, "\n");
-        }
-
         cmdNew(config, {
           title: positional[0],
           priority: (args["priority"] as string | undefined)?.toLowerCase(),
           tags: args["tags"] as string | undefined,
           source: args["source"] as string | undefined,
-          body,
+          body: args["body"] as string | undefined,
+          bodyFile: args["body-file"] as string | undefined,
           commit: args["commit"] === true,
           noDedupe: args["no-dedupe"] === true,
         });
         break;
-      }
 
       case "list":
         cmdList(config, {
@@ -353,32 +345,15 @@ function main(): void {
         cmdTags(config);
         break;
 
-      case "lint": {
-        // --only and --scope are value-bearing flags. parseArgs sets them to
-        // `true` if the user passes the flag without a value (e.g. `--only`
-        // followed by another flag or end-of-args), so coerce explicitly
-        // rather than asserting the type away.
-        const onlyArg = args["only"];
-        const scopeArg = args["scope"];
-        if (onlyArg === true) {
-          console.error("Error: --only requires a value (broken|orphans|stale|drift)");
-          process.exitCode = 2;
-          return;
-        }
-        if (scopeArg === true) {
-          console.error("Error: --scope requires a value (a directory)");
-          process.exitCode = 2;
-          return;
-        }
+      case "lint":
         cmdLint(config, {
-          only: typeof onlyArg === "string" ? onlyArg : undefined,
-          scope: typeof scopeArg === "string" ? scopeArg : undefined,
+          only: args["only"] as string | undefined,
+          scope: args["scope"] as string | undefined,
           json: args["json"] === true,
           quiet: args["quiet"] === true,
           noSuggestions: args["no-suggestions"] === true,
         });
         break;
-      }
 
       default:
         console.error(`Unknown command: ${command}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { loadConfig } from "./config.js";
 import { cmdArchive } from "./commands/archive.js";
 import { cmdDone } from "./commands/done.js";
@@ -38,6 +39,8 @@ Options (vary by command):
   --priority, -p        high, medium, or low
   --tags, -t            Comma-separated tags
   --source, -s          Where this was noticed
+  --body                Task body as inline string (use - for stdin)
+  --body-file           Task body read from file path
   --commit              Git commit after creating
   --no-dedupe           Skip duplicate detection (new)
   --status              Filter or set status
@@ -200,21 +203,72 @@ function main(): void {
 
   try {
     switch (command) {
-      case "new":
+      case "new": {
         if (!positional[0]) {
-          console.error("Usage: vt new <title> [--priority P] [--tags t1,t2] [--source S] [--commit]");
+          console.error("Usage: vt new <title> [--priority P] [--tags t1,t2] [--source S] [--commit] [--body TEXT|--body-file PATH]");
           process.exitCode = 1;
           return;
         }
+
+        const bodyArg = args["body"];
+        const bodyFileArg = args["body-file"];
+
+        if (bodyArg !== undefined && bodyFileArg !== undefined) {
+          console.error("Error: --body and --body-file are mutually exclusive. Pass one or the other.");
+          process.exitCode = 2;
+          return;
+        }
+        if (bodyArg === true) {
+          console.error("Error: --body requires a value (a string, or '-' to read from stdin).");
+          process.exitCode = 2;
+          return;
+        }
+        if (bodyFileArg === true) {
+          console.error("Error: --body-file requires a path.");
+          process.exitCode = 2;
+          return;
+        }
+
+        let body: string | undefined;
+        if (typeof bodyArg === "string") {
+          if (bodyArg === "-") {
+            try {
+              body = readFileSync(0, "utf-8");
+            } catch (err) {
+              console.error(`Error: failed to read body from stdin: ${(err as Error).message}. Pipe content into the command, e.g. cat spec.md | vt new "..." --body -`);
+              process.exitCode = 1;
+              return;
+            }
+          } else {
+            body = bodyArg;
+          }
+        } else if (typeof bodyFileArg === "string") {
+          try {
+            body = readFileSync(bodyFileArg, "utf-8");
+          } catch (err) {
+            console.error(`Error: failed to read --body-file '${bodyFileArg}': ${(err as Error).message}`);
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        // Normalize trailing newline so file output ends with exactly one \n,
+        // regardless of input source. Preserves default body shape.
+        if (body !== undefined) {
+          body = body.replace(/\n*$/, "\n");
+        }
+
         cmdNew(config, {
           title: positional[0],
           priority: (args["priority"] as string | undefined)?.toLowerCase(),
           tags: args["tags"] as string | undefined,
           source: args["source"] as string | undefined,
+          body,
           commit: args["commit"] === true,
           noDedupe: args["no-dedupe"] === true,
         });
         break;
+      }
 
       case "list":
         cmdList(config, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -213,18 +213,20 @@ function main(): void {
         const bodyArg = args["body"];
         const bodyFileArg = args["body-file"];
 
-        if (bodyArg !== undefined && bodyFileArg !== undefined) {
-          console.error("Error: --body and --body-file are mutually exclusive. Pass one or the other.");
-          process.exitCode = 2;
-          return;
-        }
-        if (bodyArg === true) {
+        // Reject missing values before mutex so the diagnostic points at the
+        // real mistake when the user typed `--body= --body-file=`.
+        if (bodyArg === true || bodyArg === "") {
           console.error("Error: --body requires a value (a string, or '-' to read from stdin).");
           process.exitCode = 2;
           return;
         }
-        if (bodyFileArg === true) {
+        if (bodyFileArg === true || bodyFileArg === "") {
           console.error("Error: --body-file requires a path.");
+          process.exitCode = 2;
+          return;
+        }
+        if (bodyArg !== undefined && bodyFileArg !== undefined) {
+          console.error("Error: --body and --body-file are mutually exclusive. Pass one or the other.");
           process.exitCode = 2;
           return;
         }
@@ -252,10 +254,10 @@ function main(): void {
           }
         }
 
-        // Normalize trailing newline so file output ends with exactly one \n,
-        // regardless of input source. Preserves default body shape.
+        // Normalize CRLF→LF (Windows interop) and trailing newline so file
+        // output is consistent across input sources (inline / stdin / file).
         if (body !== undefined) {
-          body = body.replace(/\n*$/, "\n");
+          body = body.replace(/\r\n/g, "\n").replace(/\n*$/, "\n");
         }
 
         cmdNew(config, {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -10,6 +10,7 @@ export function cmdNew(
     priority?: string;
     tags?: string;
     source?: string;
+    body?: string;
     commit?: boolean;
     noDedupe?: boolean;
   }
@@ -49,6 +50,7 @@ export function cmdNew(
     priority: args.priority,
     tags,
     source: args.source,
+    body: args.body,
   });
 
   console.log(`Created: ${store.relativePath(task.filePath)}`);

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,7 +1,57 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import type { Config } from "../config.js";
 import { similarity } from "../similarity.js";
 import { TaskStore } from "../store.js";
+
+function resolveBody(
+  bodyArg: string | undefined,
+  bodyFileArg: string | undefined
+): { body?: string; error?: { message: string; exitCode: number } } {
+  if (bodyArg !== undefined && bodyFileArg !== undefined) {
+    return {
+      error: {
+        message: "Error: --body and --body-file are mutually exclusive. Pass one or the other.",
+        exitCode: 2,
+      },
+    };
+  }
+
+  let body: string | undefined;
+  if (bodyArg !== undefined) {
+    if (bodyArg === "-") {
+      try {
+        body = readFileSync(0, "utf-8");
+      } catch (err) {
+        return {
+          error: {
+            message: `Error: failed to read body from stdin: ${(err as Error).message}. Pipe content into the command, e.g. cat spec.md | vt new "..." --body -`,
+            exitCode: 1,
+          },
+        };
+      }
+    } else {
+      body = bodyArg;
+    }
+  } else if (bodyFileArg !== undefined) {
+    try {
+      body = readFileSync(bodyFileArg, "utf-8");
+    } catch (err) {
+      return {
+        error: {
+          message: `Error: failed to read --body-file '${bodyFileArg}': ${(err as Error).message}. Verify the path exists and is readable, or pipe content via --body - instead.`,
+          exitCode: 1,
+        },
+      };
+    }
+  }
+
+  // Normalize CRLF (Windows) and collapse trailing newlines to one.
+  if (body !== undefined) {
+    body = body.replace(/\r\n/g, "\n").replace(/\n*$/, "\n");
+  }
+  return { body };
+}
 
 export function cmdNew(
   config: Config,
@@ -11,10 +61,18 @@ export function cmdNew(
     tags?: string;
     source?: string;
     body?: string;
+    bodyFile?: string;
     commit?: boolean;
     noDedupe?: boolean;
   }
 ): void {
+  const resolved = resolveBody(args.body, args.bodyFile);
+  if (resolved.error) {
+    console.error(resolved.error.message);
+    process.exitCode = resolved.error.exitCode;
+    return;
+  }
+
   const store = new TaskStore(config);
   const tags = args.tags
     ? args.tags.split(",").map((t) => t.trim())
@@ -50,7 +108,7 @@ export function cmdNew(
     priority: args.priority,
     tags,
     source: args.source,
-    body: args.body,
+    body: resolved.body,
   });
 
   console.log(`Created: ${store.relativePath(task.filePath)}`);

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -686,7 +686,7 @@ describe("CLI config validation", () => {
   it("new --body-file with no value errors", () => {
     const result = run(["new", "T", "--body-file"], dir);
     assert.equal(result.exitCode, 2);
-    assert.match(result.stderr, /--body-file requires a path/);
+    assert.match(result.stderr, /--body-file requires a value/);
   });
 
   it("new --body-file with missing path errors actionably", () => {
@@ -739,7 +739,22 @@ describe("CLI config validation", () => {
   it("new --body-file= (empty via equals) errors actionably", () => {
     const result = run(["new", "T", "--body-file="], dir);
     assert.equal(result.exitCode, 2);
-    assert.match(result.stderr, /--body-file requires a path/);
+    assert.match(result.stderr, /--body-file requires a value/);
+  });
+
+  it("value-bearing flags without a value error before crashing in commands", () => {
+    // Regression: parser used to set value-bearing flags to `true` when given
+    // no value; cmdNew/cmdEdit/cmdList would then call .toLowerCase() on the
+    // boolean and crash. Now parseArgs throws an actionable error.
+    for (const flag of ["--priority", "--tags", "--source", "--status", "--tag"]) {
+      const result = run(["new", "T", flag], dir);
+      assert.equal(result.exitCode, 2, `${flag} should exit 2`);
+      assert.match(
+        result.stderr,
+        new RegExp(`${flag.slice(2)} requires a value`),
+        `${flag} stderr should mention requires a value`
+      );
+    }
   });
 
   it("body containing frontmatter delimiters round-trips safely", () => {

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -707,4 +707,75 @@ describe("CLI config validation", () => {
     const { body } = parseFrontmatter(content);
     assert.equal(body, "# Default body\n\n");
   });
+
+  it("new --body=value accepts equals-sign syntax", () => {
+    const result = run(["new", "Eq form", "--body=inline content"], dir);
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
+    const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
+    const { body } = parseFrontmatter(content);
+    assert.equal(body, "inline content\n");
+  });
+
+  it("new --body-file=path accepts equals-sign syntax", () => {
+    const specPath = join(dir, "spec-eq.md");
+    writeFileSync(specPath, "from eq form\n");
+    const result = run(["new", "Eq file", `--body-file=${specPath}`], dir);
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
+    const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
+    const { body } = parseFrontmatter(content);
+    assert.equal(body, "from eq form\n");
+  });
+
+  it("new --body= (empty via equals) errors actionably", () => {
+    const result = run(["new", "T", "--body="], dir);
+    assert.equal(result.exitCode, 2);
+    assert.match(result.stderr, /--body requires a value/);
+  });
+
+  it("new --body-file= (empty via equals) errors actionably", () => {
+    const result = run(["new", "T", "--body-file="], dir);
+    assert.equal(result.exitCode, 2);
+    assert.match(result.stderr, /--body-file requires a path/);
+  });
+
+  it("body containing frontmatter delimiters round-trips safely", () => {
+    // Adversarial body starts with --- and contains YAML-looking lines.
+    // Supplied via --body-file because a string starting with -- would be
+    // interpreted as a flag by the arg parser.
+    const adversarial = "---\ninjected: yes\nstatus: done\n---\nreal body line";
+    const specPath = join(dir, "adversarial.md");
+    writeFileSync(specPath, adversarial);
+    const result = run(["new", "Adversarial", "--body-file", specPath], dir);
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
+    assert.equal(files.length, 1);
+    const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
+    const { meta, body } = parseFrontmatter(content);
+
+    // Frontmatter must not be polluted by body-supplied YAML-looking content
+    assert.equal(meta["title"], "Adversarial");
+    assert.equal(meta["status"], "open");
+    assert.equal(meta["injected"], undefined);
+
+    // Body round-trips verbatim (with trailing newline normalization)
+    assert.equal(body, adversarial + "\n");
+  });
+
+  it("new --body-file normalizes CRLF line endings to LF", () => {
+    const specPath = join(dir, "crlf.md");
+    writeFileSync(specPath, "line1\r\nline2\r\nline3\r\n");
+    const result = run(["new", "CRLF body", "--body-file", specPath], dir);
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
+    const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
+    assert.ok(!content.includes("\r"), "stored file must not contain carriage returns");
+    const { body } = parseFrontmatter(content);
+    assert.equal(body, "line1\nline2\nline3\n");
+  });
 });

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -743,9 +743,7 @@ describe("CLI config validation", () => {
   });
 
   it("body containing frontmatter delimiters round-trips safely", () => {
-    // Adversarial body starts with --- and contains YAML-looking lines.
-    // Supplied via --body-file because a string starting with -- would be
-    // interpreted as a flag by the arg parser.
+    // Use --body-file: an inline value starting with -- would be parsed as a flag.
     const adversarial = "---\ninjected: yes\nstatus: done\n---\nreal body line";
     const specPath = join(dir, "adversarial.md");
     writeFileSync(specPath, adversarial);
@@ -757,12 +755,9 @@ describe("CLI config validation", () => {
     const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
     const { meta, body } = parseFrontmatter(content);
 
-    // Frontmatter must not be polluted by body-supplied YAML-looking content
     assert.equal(meta["title"], "Adversarial");
     assert.equal(meta["status"], "open");
     assert.equal(meta["injected"], undefined);
-
-    // Body round-trips verbatim (with trailing newline normalization)
     assert.equal(body, adversarial + "\n");
   });
 

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -33,6 +33,26 @@ function run(args: string[], cwd: string): RunResult {
   }
 }
 
+function runWithStdin(args: string[], cwd: string, input: string): RunResult {
+  try {
+    const stdout = execFileSync("node", [CLI, ...args], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+      input,
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
 /** Write a config file that forces sequential ID strategy for backwards-compat tests */
 function writeSequentialConfig(dir: string): void {
   writeFileSync(
@@ -607,5 +627,84 @@ describe("CLI config validation", () => {
     const result = run(["list"], dir);
     assert.notEqual(result.exitCode, 0);
     assert.match(result.stderr, /dedupe_threshold/);
+  });
+
+  it("new --body writes given body inline", () => {
+    const result = run(["new", "Inline body task", "--body", "Custom body text"], dir);
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
+    assert.equal(files.length, 1);
+    const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
+    const { body } = parseFrontmatter(content);
+    assert.equal(body, "Custom body text\n");
+  });
+
+  it("new --body-file reads body from file", () => {
+    const specPath = join(dir, "spec.md");
+    writeFileSync(specPath, "# Spec\n\nDetails here.\n");
+    const result = run(["new", "From file", "--body-file", specPath], dir);
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
+    assert.equal(files.length, 1);
+    const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
+    const { body } = parseFrontmatter(content);
+    assert.equal(body, "# Spec\n\nDetails here.\n");
+  });
+
+  it("new --body - reads body from stdin", () => {
+    const result = runWithStdin(
+      ["new", "Stdin task", "--body", "-"],
+      dir,
+      "Piped body content"
+    );
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
+    assert.equal(files.length, 1);
+    const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
+    const { body } = parseFrontmatter(content);
+    assert.equal(body, "Piped body content\n");
+  });
+
+  it("new --body and --body-file are mutually exclusive", () => {
+    const result = run(
+      ["new", "T", "--body", "x", "--body-file", "y"],
+      dir
+    );
+    assert.equal(result.exitCode, 2);
+    assert.match(result.stderr, /mutually exclusive/);
+  });
+
+  it("new --body with no value errors", () => {
+    const result = run(["new", "T", "--body"], dir);
+    assert.equal(result.exitCode, 2);
+    assert.match(result.stderr, /--body requires a value/);
+  });
+
+  it("new --body-file with no value errors", () => {
+    const result = run(["new", "T", "--body-file"], dir);
+    assert.equal(result.exitCode, 2);
+    assert.match(result.stderr, /--body-file requires a path/);
+  });
+
+  it("new --body-file with missing path errors actionably", () => {
+    const missing = join(dir, "does-not-exist.md");
+    const result = run(["new", "T", "--body-file", missing], dir);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /failed to read --body-file/);
+    assert.ok(result.stderr.includes(missing), "stderr should include the failing path");
+  });
+
+  it("new without body flag preserves default body", () => {
+    const result = run(["new", "Default body"], dir);
+    assert.equal(result.exitCode, 0);
+
+    const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
+    assert.equal(files.length, 1);
+    const content = readFileSync(join(dir, "backlog", files[0]), "utf-8");
+    const { body } = parseFrontmatter(content);
+    assert.equal(body, "# Default body\n\n");
   });
 });


### PR DESCRIPTION
Lets callers seed a task with a real spec instead of the auto-generated
`# {title}` placeholder. Three input shapes: inline `--body "text"`,
`--body-file <path>`, and stdin via `--body -`. `--body` and `--body-file`
are mutually exclusive; both error actionably when passed without a value.
Body is normalized to a single trailing newline regardless of source.

https://claude.ai/code/session_01XYDr1sKUq9BqxH38WsRtVN