### PR TITLE
fix(frontmatter): preserve folded-scalar values; keep extras below standard fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented here.
 
+## Unreleased
+
+### Fixed
+
+- **Folded-scalar frontmatter values are no longer silently truncated.**
+  A YAML plain-style scalar that wrapped across an indented continuation
+  line (e.g. `title:` followed by `  recording session`) used to lose
+  everything after the first line on parse — and any subsequent `vt edit`
+  / `vt done` / `vt start` etc. would write the truncated value back to
+  disk. Continuation lines are now joined onto the parent key with a
+  single space, matching YAML's standard folding rule. ([#9](https://github.com/adcoh/vault-tasks/issues/9))
+- **Extra frontmatter fields no longer drift to the top of the block on
+  write.** Custom keys outside the known-keys set (e.g. `oncall_fix_kind`,
+  bespoke Obsidian properties) are now emitted *after* the standard
+  fields, eliminating diff noise on every save.
+
 ## 0.3.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ All notable changes to this project will be documented here.
   write.** Custom keys outside the known-keys set (e.g. `oncall_fix_kind`,
   bespoke Obsidian properties) are now emitted *after* the standard
   fields, eliminating diff noise on every save.
+- **Zero-indent block-list items are no longer silently dropped.** Tag
+  lists written at column 0 (`tags:\n- audio\n- voice-control`, the style
+  Obsidian and the reproducer in #9 both use) used to fall through every
+  regex branch in the parser and disappear, leaving `tags` as an empty
+  array. A subsequent `vt done` / `vt edit --priority …` would then
+  serialize the empty array back to disk, deleting the user's tags.
+- **Hyphen-prefixed scalar continuations are no longer misparsed as
+  list items.** A folded scalar whose continuation line starts with `-`
+  (e.g. `title: Foo\n  - bar`) used to flip the string into a single-item
+  array `["bar"]`, dropping the first line. The list-item branch is now
+  guarded so it only fires when the current key is expecting a list.
 
 ## 0.3.0
 

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -99,9 +99,20 @@ export function parseFrontmatter(
   let currentList: string[] | null = null;
 
   for (const line of fmBlock.split("\n")) {
-    // List item (e.g. "  - value")
-    const listMatch = line.match(/^\s+-\s+(.+)$/);
-    if (listMatch && currentKey) {
+    // List item (e.g. "- value" or "  - value"). YAML 1.2 allows a block
+    // sequence at the same indent as its parent mapping key, so we accept
+    // zero or more leading spaces. The guard is critical: a `- foo` line
+    // is only a list item when the current key is *expecting* one — i.e.
+    // we're already inside a list, or its value is the empty string
+    // (signaling "value follows on the next lines"). Otherwise an indented
+    // continuation like `title: Foo\n  - bar` would silently convert the
+    // string scalar into a list and drop the first line.
+    const listMatch = line.match(/^\s*-\s+(.+)$/);
+    if (
+      listMatch &&
+      currentKey !== null &&
+      (currentList !== null || meta[currentKey] === "")
+    ) {
       if (currentList === null) {
         currentList = [];
       }

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -110,6 +110,29 @@ export function parseFrontmatter(
       continue;
     }
 
+    // Folded-scalar continuation. A YAML plain-style scalar can wrap across
+    // multiple indented lines:
+    //
+    //     title: Long title that wraps
+    //       across two lines
+    //
+    // YAML joins those with a single space. Without this branch, the
+    // continuation line matches neither the list nor kv regex above and is
+    // silently dropped — the parsed `title` becomes just the first line,
+    // and a write-back truncates the file. Only fires when the current key
+    // is a string (not a list) and the line is indented + non-empty.
+    if (
+      currentKey !== null &&
+      currentList === null &&
+      typeof meta[currentKey] === "string" &&
+      /^\s+\S/.test(line)
+    ) {
+      const prev = meta[currentKey] as string;
+      const cont = line.trim();
+      meta[currentKey] = prev ? `${prev} ${cont}` : cont;
+      continue;
+    }
+
     // Key-value pair — allow dots, hyphens, underscores in keys
     const kvMatch = line.match(/^([\w][\w.\-]*):\s*(.*)$/);
     if (kvMatch) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -85,14 +85,20 @@ function fileToTask(filePath: string, text: string): Task {
 }
 
 function taskToMarkdown(task: Task): string {
+  // Known keys first, extras LAST. Spreading `extraMeta` first would drift
+  // unknown frontmatter fields (e.g. `oncall_fix_kind`, custom Obsidian
+  // properties) to the TOP of the frontmatter block on every save, churning
+  // git diffs without changing data. `fileToTask` filters out known keys
+  // before populating `extraMeta`, so there's no clobber risk from doing
+  // the spread last.
   const meta: Record<string, unknown> = {
-    ...task.extraMeta,
     title: task.title,
     status: task.status,
     priority: task.priority,
     tags: task.tags,
     created: task.created,
     source: task.source,
+    ...task.extraMeta,
   };
   return writeFrontmatter(meta, task.body);
 }

--- a/src/tests/frontmatter.test.ts
+++ b/src/tests/frontmatter.test.ts
@@ -213,6 +213,40 @@ Body`;
     assert.equal(meta["title"], "First line second line");
     assert.deepEqual(meta["tags"], ["audio", "voice"]);
   });
+
+  it("parses zero-indent block-list items", () => {
+    // YAML 1.2 allows a block sequence at the same indent as its parent
+    // mapping key. The exact reproducer file from #9 used this style;
+    // before the fix, every `- tag` line silently fell through every
+    // regex branch and was dropped, leaving `tags` as an empty array.
+    // The user only masked this by re-supplying all tags in `--tags`.
+    const text = `---
+tags:
+- audio
+- voice-control
+- permissions
+---
+Body`;
+    const { meta } = parseFrontmatter(text);
+    assert.deepEqual(meta["tags"], ["audio", "voice-control", "permissions"]);
+  });
+
+  it("treats `- foo` as scalar continuation, not a list, when key already has a value", () => {
+    // Adversarial input from qodo review: a continuation line whose first
+    // non-whitespace char is `-` must NOT silently flip a string scalar
+    // into a list (which would drop the first line). The listMatch
+    // branch is guarded against firing when `meta[currentKey]` is
+    // already a non-empty string.
+    const text = `---
+title: Foo
+  - bar
+status: open
+---
+Body`;
+    const { meta } = parseFrontmatter(text);
+    assert.equal(meta["title"], "Foo - bar");
+    assert.equal(meta["status"], "open");
+  });
 });
 
 describe("writeFrontmatter", () => {
@@ -326,23 +360,27 @@ tags:
     // CLAUDE.md: "round-trip safety is non-negotiable —
     // parse(write(data)) must return the same data." A title that arrives
     // as a YAML folded scalar must survive parse→write→parse intact, even
-    // if write emits it on a single line.
+    // if write emits it on a single line. Asserts full deep equality of
+    // the meta object — not just selected fields — so future regressions
+    // that silently coerce or drop a key are caught.
     const original = `---
 title: Voice control modal repeatedly appears with audio format validation error after
   recording session
 status: open
 priority: high
+tags:
+  - audio
+  - voice-control
 ---
 Body`;
     const { meta } = parseFrontmatter(original);
     const written = writeFrontmatter(meta, "Body");
     const { meta: roundTripped } = parseFrontmatter(written);
+    assert.deepEqual(roundTripped, meta);
     assert.equal(
       roundTripped["title"],
       "Voice control modal repeatedly appears with audio format validation error after recording session"
     );
-    assert.equal(roundTripped["status"], "open");
-    assert.equal(roundTripped["priority"], "high");
   });
 
   it("round-trips a purely-numeric id string without becoming a number", () => {

--- a/src/tests/frontmatter.test.ts
+++ b/src/tests/frontmatter.test.ts
@@ -156,6 +156,63 @@ More text`;
     const { meta } = parseFrontmatter(text);
     assert.deepEqual(meta["tags"], ["auth", "security"]);
   });
+
+  it("joins folded-scalar continuation lines onto the parent key", () => {
+    // YAML plain-style folding: a long value can wrap across indented
+    // continuation lines, joined with a single space on parse.
+    // Falsifying test for the data-loss bug where continuation lines
+    // matched neither the list nor kv regex and were silently dropped,
+    // truncating the parsed value to just the first line.
+    const text = `---
+title: Voice control modal repeatedly appears with audio format validation error after
+  recording session
+status: open
+---
+Body`;
+    const { meta } = parseFrontmatter(text);
+    assert.equal(
+      meta["title"],
+      "Voice control modal repeatedly appears with audio format validation error after recording session"
+    );
+    assert.equal(meta["status"], "open");
+  });
+
+  it("joins multiple folded-scalar continuation lines", () => {
+    const text = `---
+title: One
+  two
+  three
+---
+Body`;
+    const { meta } = parseFrontmatter(text);
+    assert.equal(meta["title"], "One two three");
+  });
+
+  it("handles folded scalar where parent key has empty initial value", () => {
+    // `title:` with no inline value followed by an indented continuation —
+    // the continuation should NOT be prefixed with a leading space.
+    const text = "---\ntitle:\n  starts on next line\n---\nBody";
+    const { meta } = parseFrontmatter(text);
+    assert.equal(meta["title"], "starts on next line");
+  });
+
+  it("does not absorb subsequent block-list items into a folded scalar", () => {
+    // Critical invariant: a folded scalar must not accidentally swallow
+    // the start of a following list. After `title:` wraps onto its
+    // continuation, the next `tags:` line resets `currentKey` and the
+    // `- audio` line must be parsed as a list item.
+    const text = `---
+title: First line
+  second line
+tags:
+  - audio
+  - voice
+---
+Body`;
+    const { meta } = parseFrontmatter(text);
+    assert.equal(meta["title"], "First line second line");
+    assert.deepEqual(meta["tags"], ["audio", "voice"]);
+  });
 });
 
 describe("writeFrontmatter", () => {
@@ -263,6 +320,29 @@ tags:
     );
     assert.equal(parsed["id"], ulid);
     assert.equal(typeof parsed["id"], "string");
+  });
+
+  it("round-trips folded-scalar titles without data loss", () => {
+    // CLAUDE.md: "round-trip safety is non-negotiable —
+    // parse(write(data)) must return the same data." A title that arrives
+    // as a YAML folded scalar must survive parse→write→parse intact, even
+    // if write emits it on a single line.
+    const original = `---
+title: Voice control modal repeatedly appears with audio format validation error after
+  recording session
+status: open
+priority: high
+---
+Body`;
+    const { meta } = parseFrontmatter(original);
+    const written = writeFrontmatter(meta, "Body");
+    const { meta: roundTripped } = parseFrontmatter(written);
+    assert.equal(
+      roundTripped["title"],
+      "Voice control modal repeatedly appears with audio format validation error after recording session"
+    );
+    assert.equal(roundTripped["status"], "open");
+    assert.equal(roundTripped["priority"], "high");
   });
 
   it("round-trips a purely-numeric id string without becoming a number", () => {

--- a/src/tests/store.test.ts
+++ b/src/tests/store.test.ts
@@ -175,13 +175,20 @@ describe("TaskStore", () => {
     store.update("1", { priority: "high" });
 
     const afterUpdate = readFileSync(task.filePath, "utf-8");
-    const titleIdx = afterUpdate.indexOf("title:");
+    // Pin against ALL known keys, not just the first. The original bug
+    // moved every known key below extras; a regression where only one
+    // known key (e.g. `source`) drifted would slip past a `title < extra`
+    // assertion.
     const extraIdx = afterUpdate.indexOf("oncall_fix_kind:");
-    assert.ok(titleIdx >= 0 && extraIdx >= 0, "both fields must be present");
-    assert.ok(
-      titleIdx < extraIdx,
-      `extra meta must appear AFTER known keys; got title@${titleIdx} extra@${extraIdx}`
-    );
+    assert.ok(extraIdx >= 0, "extra meta key must be present");
+    for (const knownKey of ["title:", "status:", "priority:", "tags:", "created:", "source:"]) {
+      const knownIdx = afterUpdate.indexOf(knownKey);
+      assert.ok(knownIdx >= 0, `${knownKey} must be present`);
+      assert.ok(
+        knownIdx < extraIdx,
+        `${knownKey} must appear before extras; got ${knownKey}@${knownIdx} extra@${extraIdx}`
+      );
+    }
   });
 
   it("rejects invalid priority", () => {

--- a/src/tests/store.test.ts
+++ b/src/tests/store.test.ts
@@ -158,6 +158,32 @@ describe("TaskStore", () => {
     assert.equal(afterUpdate.extraMeta["due"], "2026-04-15");
   });
 
+  it("keeps extra meta fields below the known fields on update", () => {
+    // Falsifying test for the diff-noise bug where `taskToMarkdown` spread
+    // `...extraMeta` BEFORE the known keys, drifting custom frontmatter
+    // (e.g. `oncall_fix_kind`) to the top of the block on every write.
+    // The relative order of `title`, `status`, `priority`, `tags`,
+    // `created`, `source` must come before any extra key after an update.
+    const task = store.create({ title: "Order check" });
+    const content = readFileSync(task.filePath, "utf-8");
+    const modified = content.replace(
+      "\n---\n",
+      "\noncall_fix_kind: real-bug\n---\n"
+    );
+    writeFileSync(task.filePath, modified);
+
+    store.update("1", { priority: "high" });
+
+    const afterUpdate = readFileSync(task.filePath, "utf-8");
+    const titleIdx = afterUpdate.indexOf("title:");
+    const extraIdx = afterUpdate.indexOf("oncall_fix_kind:");
+    assert.ok(titleIdx >= 0 && extraIdx >= 0, "both fields must be present");
+    assert.ok(
+      titleIdx < extraIdx,
+      `extra meta must appear AFTER known keys; got title@${titleIdx} extra@${extraIdx}`
+    );
+  });
+
   it("rejects invalid priority", () => {
     assert.throws(() => store.create({ title: "Bad", priority: "urgent" }), /Invalid priority/);
   });


### PR DESCRIPTION
Closes #9.

## Summary

Two round-trip bugs in the handrolled YAML parser/writer:

1. **Data loss** — folded-scalar continuation lines (a YAML plain-style scalar wrapped across indented lines) were silently dropped on parse, truncating values like multi-line titles. Any subsequent \`vt edit\` / \`vt done\` / \`vt start\` round-tripped the truncated value back to disk.
2. **Diff noise** — extra frontmatter keys (custom Obsidian properties, per-vault conventions like \`oncall_fix_kind\`) drifted to the top of the frontmatter block on every \`update()\` because \`taskToMarkdown\` spread \`...extraMeta\` *before* the known keys.

Issue #9 has the full reproducer and the originally-misdiagnosed cause (I initially guessed a YAML-library round-trip issue; the actual cause is a missing branch in the handrolled parser).

## Root cause

\`parseFrontmatter\`'s per-line loop only recognized two shapes — list items (\`^\s+-\s+...\`) and key-value pairs (\`^key:\s*...\`). A YAML continuation line like

\`\`\`yaml
title: Long value
  that wraps
\`\`\`

produces a line \`  that wraps\` that matches **neither**. The loop silently skipped it, so \`meta.title\` ended up as just \`\"Long value\"\`. \`writeFrontmatter\` then faithfully emitted the truncated value, locking the corruption into the file.

For #2: \`taskToMarkdown\` had \`{ ...task.extraMeta, title, status, priority, tags, created, source }\`. Spreading first meant any custom key surfaced above the known ones on every save.

## Fix

**\`src/frontmatter.ts\`** — add a third branch in \`parseFrontmatter\`'s per-line loop:

\`\`\`ts
// Folded-scalar continuation. Joins indented non-list lines onto the
// parent string-valued key with a single space, matching YAML's
// plain-style folding behavior.
if (
  currentKey !== null &&
  currentList === null &&
  typeof meta[currentKey] === \"string\" &&
  /^\s+\S/.test(line)
) {
  const prev = meta[currentKey] as string;
  const cont = line.trim();
  meta[currentKey] = prev ? \`\${prev} \${cont}\` : cont;
  continue;
}
\`\`\`

The \`currentList === null\` guard prevents this branch from accidentally absorbing list items into the previous scalar.

**\`src/store.ts\`** — move \`...task.extraMeta\` to the tail of the meta object in \`taskToMarkdown\`. \`fileToTask\` already filters \`KNOWN_META_KEYS\` out of \`extraMeta\`, so there's no overlap or clobber risk.

## Tests (all falsifying)

\`src/tests/frontmatter.test.ts\` — 5 new:

- Folded scalar parses with the exact \`voice control modal ... recording session\` reproducer from #9
- Multi-line folded scalar (3 continuation lines) joins with spaces
- Empty initial value: \`title:\n  foo\` produces \`\"foo\"\`, not \`\" foo\"\`
- Folded scalar followed by a \`tags:\` list still parses the list correctly (no accidental absorption)
- Round-trip safety: \`parse → write → parse\` preserves the joined title

\`src/tests/store.test.ts\` — 1 new:

- After \`update()\`, an extra frontmatter key appears AFTER \`title:\` in the rewritten file, not before. Pin against regression of the reordering bug.

## Test results

\`\`\`
ℹ tests 294
ℹ suites 35
ℹ pass 294
ℹ fail 0
\`\`\`

## What's intentionally NOT fixed in this PR

- **Quote-style normalization** (\`source: '[[…]]'\` → \`source: \"[[…]]\"\` on round-trip) — purely cosmetic, would require parse-time capture of quote style. Filing as a follow-up if desired.
- **Block list indentation** (writer always emits \`  - foo\`, even if original was \`- foo\` at column 0) — also cosmetic; would need parse-time capture of indent. Follow-up if desired.

## Cross-references

- Issue: #9
- Surfaced during BioForm-AI/bioform-vault PR #144 (audit-respond skill caught the diff before the title corruption was committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)