### PR TITLE
CLAUDE.md: add Communication Style rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,13 +35,19 @@ node dist/cli.js <command>         # run locally
 
 ## Communication Style
 
-All agent output (PR comments, reviews, code comments, JSDoc, error messages, commit messages, chat replies, README updates) follows three rules:
+All agent output (PR comments, reviews, code comments, JSDoc, error messages, commit messages, chat replies, README updates) follows three core rules. Surface-specific shape comes after.
 
-1. **Reference > recap.** Link to `src/file.ts:42` or a doc. Recap only when the reader can't follow without it — then ≤2 sentences + the link. Error messages tell the user what to do, not what happened in prose.
-2. **Diagram before prose** for anything with ≥3 moving parts (CLI command flow, store lifecycle, frontmatter round-trip, ID allocation paths). Use Mermaid on GitHub-rendered surfaces. One diagram beats four paragraphs.
+### Three core rules
+
+1. **Reference > recap.** Link to `src/file.ts:42` or a doc. Recap only when the reader can't follow without it — then ≤2 sentences + the link.
+2. **Prefer a diagram over prose for non-trivial structure** on surfaces that render Markdown/Mermaid (PRs, GitHub READMEs, design docs). For anything with ≥3 moving parts (CLI command flow, store lifecycle, frontmatter round-trip, ID allocation paths), a Mermaid diagram beats four paragraphs. On plain-text surfaces (commit messages, error messages, terminal output, chat replies) substitute a tight prose summary.
 3. **Every sentence earns its place.** No preambles, no sign-offs, no restating the diff in a PR body.
 
-PR comments lead with verdict (`LGTM` / `Needs changes` / `Question`) and group findings by severity (`Blocker`, `Should fix`, `Nit`). For a public npm package, the verdict is real — `Blocker` means the change ships an issue to strangers' machines. Calibrate the severity tag honestly.
+### Per-surface specifics (extending the core rules)
+
+- **PR comments**: lead with verdict (`LGTM` / `Needs changes` / `Question`); group findings by severity (`Blocker` / `Should fix` / `Nit`). For a public npm package, `Blocker` means the change ships an issue to strangers' machines — calibrate honestly.
+- **Error messages**: lead with the actionable step; if the cause isn't obvious from the action, follow with one tight clause naming the cause (e.g. `Task '42' is archived; move it back to backlog to modify.`). This is fully consistent with the Code Review Standard's "tell the user what happened AND what to do" — action first, cause second, one line.
+- **Commit messages**: single-line subject in imperative mood, ≤72 chars. Body only when *why* isn't obvious.
 
 ## Code Review Standard
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,16 @@ node dist/cli.js <command>         # run locally
 - All task data lives in markdown files with YAML frontmatter.
 - Config is `.vault-tasks.toml` discovered by walking up from CWD.
 
+## Communication Style
+
+All agent output (PR comments, reviews, code comments, JSDoc, error messages, commit messages, chat replies, README updates) follows three rules:
+
+1. **Reference > recap.** Link to `src/file.ts:42` or a doc. Recap only when the reader can't follow without it — then ≤2 sentences + the link. Error messages tell the user what to do, not what happened in prose.
+2. **Diagram before prose** for anything with ≥3 moving parts (CLI command flow, store lifecycle, frontmatter round-trip, ID allocation paths). Use Mermaid on GitHub-rendered surfaces. One diagram beats four paragraphs.
+3. **Every sentence earns its place.** No preambles, no sign-offs, no restating the diff in a PR body.
+
+PR comments lead with verdict (`LGTM` / `Needs changes` / `Question`) and group findings by severity (`Blocker`, `Should fix`, `Nit`). For a public npm package, the verdict is real — `Blocker` means the change ships an issue to strangers' machines. Calibrate the severity tag honestly.
+
 ## Code Review Standard
 
 You are the sole maintainer of a public npm package. Every line you write or approve will run on strangers' machines, in their vaults, with their data. Act like it. Review your own output with the same hostility you'd bring to a PR from someone you don't trust.


### PR DESCRIPTION
## Summary

Three rules for all agent output. Verdict-first PR comments; severity tags calibrated honestly — `Blocker` on a public npm package means the change ships an issue to strangers' machines.

Sits above the existing Code Review Standard since the style rules govern how findings are communicated; the standard governs what counts as a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)