### PR TITLE
ci(publish): switch npm publish to Trusted Publishing (drop NPM_TOKEN)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,9 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      id-token: write  # required for npm Trusted Publishing (OIDC) and provenance
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -66,6 +64,11 @@ jobs:
         with:
           name: package-tarball
 
+      # Trusted Publishing: no NPM_TOKEN. The npm registry trusts this exact
+      # workflow on this repo (configure under Package settings → Trusted
+      # Publishers on npmjs.com). Authentication uses the same OIDC token
+      # GitHub already issues for provenance, so the publisher identity and
+      # the build provenance are signed by the same trust chain.
       - name: Publish with provenance
         run: npm publish vault-tasks-*.tgz --provenance --access public
 


### PR DESCRIPTION
## Summary

Drops `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the `publish-npm` job. With Trusted Publishing configured on npmjs.com, authentication uses the same OIDC token GitHub already mints for provenance — one trust chain for both publisher identity and build attestation, no long-lived secret to rotate.

Matches the `publish-pypi` job, which already uses PyPI Trusted Publishing for the same reason.

## Context

The v0.5.0 publish (release event ~1h ago) failed with `npm error 404 - PUT https://registry.npmjs.org/vault-tasks - Not found` after successful provenance signing. npm returns 404 (not 401) for authenticated-write failures when the bearer is empty/expired/revoked — diagnostic walk-through:

- Provenance signing succeeded → OIDC + sigstore are healthy
- The exact same workflow YAML published 0.4.0 cleanly on 2026-05-12
- `vault-tasks` exists on npm, owned by `adcoh` (verified via public registry)
- Only the final `PUT /vault-tasks` failed

Net: the `NPM_TOKEN` secret is missing, expired, or invalid. Trusted Publishing eliminates the dependency entirely.

## REQUIRED before merge

This PR alone won't unblock the 0.5.0 publish. Need this one-time npm-side setup first:

1. npmjs.com → `vault-tasks` → **Settings → Trusted Publishers → Add publisher**
   - Publisher: **GitHub Actions**
   - Organization or user: `adcoh`
   - Repository: `vault-tasks`
   - Workflow filename: `publish.yml`
   - Environment: *(leave blank — workflow does not use one)*
2. (Optional but recommended) Delete the `NPM_TOKEN` repo secret afterward.

Once configured, merge this PR, then **re-run the failed `publish-npm` job** on the v0.5.0 release run — GitHub uses the workflow YAML as it currently exists on `main` at the time of the re-run, so the new no-token path will be taken and 0.5.0 should land.

## Test plan

- [x] `git diff` minimal — only the `publish-npm` job is touched; `publish-pypi` and `publish-testpypi` are unchanged
- [x] `permissions: id-token: write` retained (still required for OIDC)
- [x] `actions/setup-node` step retained with `registry-url: https://registry.npmjs.org` (configures `.npmrc` for the OIDC exchange)
- [ ] After merge: re-run `publish-npm` on the v0.5.0 release run and confirm `vault-tasks@0.5.0` appears on `registry.npmjs.org`

---
_Generated by [Claude Code](https://claude.ai/code/session_011YtPtRVA4aAqNEzziLd2bc)_