### PR TITLE
README: agent-actionable framing + PWYW kit + Sponsors hub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# Enables the "Sponsor" button on the repo.
+# NOTE: the GitHub Sponsors *program* must be activated separately at
+# github.com/sponsors (profile, tiers, payout/bank) before this resolves.
+github: [adcoh]
+# Optional alternatives once set up:
+# ko_fi: <username>
+# buy_me_a_coffee: <username>
+# polar: <username>
+# custom: ["https://agentvaultkit.gumroad.com/l/iueeo"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # vault-tasks
 
-Markdown-file task manager for solo devs building with [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+**A backlog your AI agent can _operate_ — not just read.**
 
-Tasks are plain markdown files with YAML frontmatter. They live in your repo (or Obsidian vault), are version-controlled with git, and are readable by humans and LLMs alike. Zero runtime dependencies.
+`vault-tasks` (`vt`) is a Markdown-file task manager for solo devs building with AI agents — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Codex, Cursor, Hermes, anything that runs a shell. Tasks are plain Markdown with YAML frontmatter: they live in your repo or Obsidian vault, version-control with git, and read cleanly to humans and LLMs alike. No database, no API key, no MCP server, no cloud. Zero runtime dependencies.
+
+Your agent runs `vt new`, `vt list`, `vt lint` directly — so "triage my backlog" actually *does* something.
+
+Every feature here exists because I hit a wall using it on real work and filed an issue against this repo. The issue tracker is a changelog of my own mistakes — go read it. — *Adam*
+
+## Build in public
+
+Dogfooded across real projects (400+ tasks tracked, ~190 closed); every release written by use, not a spec.
+
+- **The story:** _"I didn't build the Agent-Ready Vault Kit. My agent did."_ — article _(coming)_
+- **Done-for-you setup:** the **[Agent-Ready Vault Kit](https://agentvaultkit.gumroad.com/l/iueeo)** wraps `vt` + an opinionated Obsidian vault (PARA + zettelkasten, agent-neutral `.agent/` substrate, agent skills, a Hermes profile starter) into a $19 one-time starter. `vt` stays free and MIT — the Kit is just the curated setup. _(launching soon)_
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Every feature here exists because I hit a wall using it on real work and filed a
 Dogfooded across real projects (400+ tasks tracked, ~190 closed); every release written by use, not a spec.
 
 - **The story:** _"I didn't build the Agent-Ready Vault Kit. My agent did."_ — article _(coming)_
-- **Done-for-you setup:** the **[Agent-Ready Vault Kit](https://agentvaultkit.gumroad.com/l/iueeo)** wraps `vt` + an opinionated Obsidian vault (PARA + zettelkasten, agent-neutral `.agent/` substrate, agent skills, a Hermes profile starter) into a $19 one-time starter. `vt` stays free and MIT — the Kit is just the curated setup. _(launching soon)_
+- **Done-for-you setup:** the **[Agent-Ready Vault Kit](https://agentvaultkit.gumroad.com/l/iueeo)** wraps `vt` + an opinionated Obsidian vault (PARA + zettelkasten, agent-neutral `.agent/` substrate, agent skills, a Hermes profile starter). **Pay what you want — including free.** `vt` and the Kit are both free; tip if it's useful. _(launching soon)_
+
+## Support
+
+`vt` is free and MIT, and stays that way. If it saves you time, you can back its development via [GitHub Sponsors](https://github.com/sponsors/adcoh) — sponsors get early access to new features and a spot on the backers list. _(sponsor tiers coming)_
 
 ## Install
 


### PR DESCRIPTION
## Summary
Turn the README into a more deliberate top-of-funnel + reflect the monetization pivot (research-backed): the Kit is **pay-what-you-want / free** (a lead magnet), and the durable monetization is the **content engine + GitHub Sponsors** around the free MIT tool — not a fixed-price wrapper.

## What changed
- **Intro** — lead with "a backlog your AI agent can *operate*"; broaden harness mentions; named-maker + issue-tracker-as-changelog credibility.
- **Build-in-public** — links the story article + the Kit (now **pay-what-you-want, incl. free**).
- **New "Support" section** + `.github/FUNDING.yml` — wires the Sponsor button (sponsors get early access + backers spot).
- Install / usage / API — unchanged.

## Pending before merge (draft)
- Story article link is a placeholder _(coming)_.
- **GitHub Sponsors program** must be activated at github.com/sponsors (profile, tiers, payout) before the Sponsor button resolves — a manual step.
- Kit link points to a Gumroad draft _(launching soon)_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)