### PR TITLE
ci(publish): upgrade npm before publish so trusted publishing kicks in

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,15 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # Trusted publisher auto-detection requires npm CLI >= 11.5.1 (released
+      # Aug 2025). Node 22 still ships npm 10.x by default, which signs
+      # provenance via OIDC but does NOT auto-authenticate via OIDC for the
+      # publish itself — producing a misleading `404 PUT /vault-tasks` from
+      # the registry's catch-all unauthenticated-write path. Bump to the
+      # latest npm before publishing.
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,10 +63,13 @@ jobs:
       # Aug 2025). Node 22 still ships npm 10.x by default, which signs
       # provenance via OIDC but does NOT auto-authenticate via OIDC for the
       # publish itself — producing a misleading `404 PUT /vault-tasks` from
-      # the registry's catch-all unauthenticated-write path. Bump to the
-      # latest npm before publishing.
+      # the registry's catch-all unauthenticated-write path. Pin to the
+      # ^11.5.1 range so releases stay reproducible (no surprise major
+      # bumps to npm 12.x) while still picking up patch fixes.
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+        run: |
+          npm install -g 'npm@^11.5.1'
+          npm --version
 
       - name: Download artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,13 +59,14 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      # Trusted publisher auto-detection requires npm CLI >= 11.5.1 (released
-      # Aug 2025). Node 22 still ships npm 10.x by default, which signs
-      # provenance via OIDC but does NOT auto-authenticate via OIDC for the
-      # publish itself — producing a misleading `404 PUT /vault-tasks` from
-      # the registry's catch-all unauthenticated-write path. Pin to the
-      # ^11.5.1 range so releases stay reproducible (no surprise major
-      # bumps to npm 12.x) while still picking up patch fixes.
+      # Trusted publisher auto-detection requires npm CLI >= 11.5.1
+      # (GA'd 2025-07-31). The npm bundled with actions/setup-node@v6 +
+      # Node 22 may be older than that — older CLIs sign provenance via
+      # OIDC but do NOT auto-authenticate via OIDC for the publish itself,
+      # producing a misleading `404 PUT /vault-tasks` from the registry's
+      # catch-all unauthenticated-write path. Pin to the ^11.5.1 range so
+      # releases stay reproducible (no surprise major bumps to npm 12.x)
+      # while still picking up patch fixes.
       - name: Upgrade npm for Trusted Publishing
         run: |
           npm install -g 'npm@^11.5.1'


### PR DESCRIPTION
## Summary

One-line fix: upgrade npm before the publish step so trusted-publisher auto-detection actually kicks in.

## Why the v0.5.1 publish-npm still failed

After #18 dropped `NPM_TOKEN` and pointed the workflow at trusted publishing, the v0.5.1 release run produced an identical-looking `404 PUT /vault-tasks` to the v0.5.0 failure. From the actual job log (verified via Actions API, not screenshots):

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1750664293
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/vault-tasks - Not found
```

**Provenance signing worked** — the OIDC plumbing and sigstore exchange are healthy. But the CLI never says *"authenticated via trusted publisher"*; it walks straight to the PUT with no auth, and the registry returns its catch-all 404.

Cause: **npm CLI version**. `actions/setup-node@v6` with `node-version: 22` ships npm 10.9.x. **Trusted-publisher auto-detection was added in npm CLI 11.5.1** (Aug 2025). Pre-11.5.1, the CLI signs provenance via OIDC but does NOT use OIDC for the publish itself — so with no `NODE_AUTH_TOKEN` in the environment, the request goes out unauthenticated.

## The fix

```yaml
- name: Upgrade npm for Trusted Publishing
  run: npm install -g npm@latest
```

Inserted between `setup-node` and `Download artifact`. Adds ~5 seconds to the job.

## What this PR does NOT unblock

`v0.5.0` and `v0.5.1` are stuck on npm. The fix only takes effect on **a new release event** (re-runs of release-triggered workflows use the YAML from the tagged commit, not current main — confirmed by reading attempt-2 logs of the original 0.5.0 run).

User-side recommendation (out of scope for this PR): publish `0.5.1` manually with a local `npm publish --provenance` to land it today, then the next minor/patch will publish cleanly via CI.

## Test plan

- [x] `git diff` is the single inserted step
- [x] YAML syntax valid (no destructured/anchored blocks touched)
- [x] `id-token: write` permission and `actions/setup-node` registry-url config preserved
- [ ] After merge: next release event publishes vault-tasks via trusted publishing without intervention

---
_Generated by [Claude Code](https://claude.ai/code/session_011YtPtRVA4aAqNEzziLd2bc)_