### PR TITLE
docs: build log + evergreen note for BM25 + release saga

### DIFF
--- a/01-journal/2026/2026-06-10 0245 BM25 Search Module and npm Trusted-Publishing Saga.md
+++ b/01-journal/2026/2026-06-10 0245 BM25 Search Module and npm Trusted-Publishing Saga.md
@@ -54,6 +54,19 @@ release pipeline.
 This is the valuable part — the release took **four PRs and three failed publish
 attempts** because each fix revealed the next layer.
 
+```mermaid
+flowchart TD
+    A[v0.5.0 release] --> B{publish-npm}
+    B -->|404: NPM_TOKEN missing/expired| C["#18: drop token,<br/>use Trusted Publishing"]
+    C --> D[re-run v0.5.0 job]
+    D -->|"still 404: re-run uses<br/>tagged-commit YAML, not main"| E["#22: cut fresh v0.5.1<br/>+ artifact retention 1 to 7d"]
+    E --> F[re-run v0.5.1 job]
+    F -->|artifact expired after 50h| G[v0.5.1 release]
+    G -->|"404 again: npm 10.x signs<br/>provenance but no OIDC auth"| H["#24: install npm@^11.5.1"]
+    H --> I["local publish 0.5.1:<br/>--provenance fails (CI-only)"]
+    I --> J([publish without provenance<br/>→ 0.5.1 LIVE on npm])
+```
+
 1. **v0.5.0 npm publish failed: `404 PUT /vault-tasks`.** Misleading — npm returns
    404, not 401, for unauthenticated writes. Root cause: the `NPM_TOKEN` secret was
    missing/expired. PyPI published fine (independent Trusted Publishing). *Fixed in

--- a/01-journal/2026/2026-06-10 0245 BM25 Search Module and npm Trusted-Publishing Saga.md
+++ b/01-journal/2026/2026-06-10 0245 BM25 Search Module and npm Trusted-Publishing Saga.md
@@ -1,0 +1,126 @@
+---
+title: "BM25 Search Module + the npm Trusted-Publishing Saga"
+date: 2026-06-10
+tags:
+  - build-log
+  - vault-tasks
+  - search
+  - ci
+  - release
+source: "[[vault-tasks]]"
+---
+
+## What we built
+
+Shipped an optional BM25 ranked-search module and got vault-tasks **0.5.1 live on
+both npm and PyPI** — the latter after a four-PR debugging chain through the
+release pipeline.
+
+**Feature work (PR #15):**
+- New `vault-tasks/search` subpath export — zero-dependency, in-memory BM25 over
+  `title title tags body` document construction, plus a Unicode-aware tokenizer.
+  Public API: `searchTasks`, `similarTasks`, `BM25Index`, `tokenize`.
+- CLI: `vt search --mode bm25`, `--like <id>` (task-to-task similarity, works on
+  archived tasks), `--limit N`. Default `keyword` mode is byte-identical to 0.4.x.
+- `TaskStore.findIncludingArchive()` — read-only archive lookup that doesn't trip
+  the modify-time guardrail.
+- 359 tests passing (was 342).
+
+**Hostile self-review of #15 (16 findings, all fixed before merge):**
+- Unbounded BM25 memory → 2 MB / 100k-token document caps (a 3 MB body OOM'd a
+  512 MB heap pre-fix).
+- `STATUS_DISPLAY[status]` prototype-chain crash on `status: constructor` →
+  `Object.hasOwn` guard.
+- ANSI / newline / control-char injection via task fields → central
+  `sanitizeForDisplay` at every render site.
+- `--limit`/`--days` accepted `5abc`, `2.5`, `1e20` → strict
+  `Number.isSafeInteger` validation.
+- `SearchMode` narrowed to `'keyword' | 'bm25'` so `'semantic' | 'hybrid'` fail
+  at compile time instead of runtime.
+- `main().catch` printed literal `undefined` for non-Error rejections → typed
+  `errorMessage()` helper.
+- Keyword `--limit` sliced before priority sort (dropped high-priority matches) →
+  sort-then-slice.
+- Plus library/CLI default-mode alignment, tag-scope alignment, dead IDF guards
+  removed.
+
+**Release plumbing (PRs #18, #22, #24):**
+- #18: switched npm publish from `NPM_TOKEN` to Trusted Publishing (OIDC).
+- #22: bumped 0.5.0 → 0.5.1, artifact `retention-days` 1 → 7.
+- #24: pinned `npm@^11.5.1` before the publish step (the actual fix).
+
+## What broke / didn't work
+
+This is the valuable part — the release took **four PRs and three failed publish
+attempts** because each fix revealed the next layer.
+
+1. **v0.5.0 npm publish failed: `404 PUT /vault-tasks`.** Misleading — npm returns
+   404, not 401, for unauthenticated writes. Root cause: the `NPM_TOKEN` secret was
+   missing/expired. PyPI published fine (independent Trusted Publishing). *Fixed in
+   #18 by dropping the token for Trusted Publishing.*
+
+2. **Re-running the failed v0.5.0 job didn't pick up the #18 fix.** Re-runs of
+   **release-triggered** workflows use the YAML at the *tagged commit*, not current
+   `main`. Confirmed by reading the attempt-2 log: it still showed
+   `NODE_AUTH_TOKEN: ***`. *Worked around by cutting a fresh v0.5.1 in #22.*
+
+3. **v0.5.1 re-run then failed on artifact download.** The build artifact had
+   `retention-days: 1` and the re-run was ~50 h later → expired. *Fixed in #22 by
+   bumping to 7 days.*
+
+4. **v0.5.1 npm publish failed: `404 PUT /vault-tasks` again — but different cause.**
+   Provenance signing *succeeded* (OIDC healthy, sigstore log entry present), yet the
+   publish PUT went out unauthenticated. Root cause: **npm CLI version**.
+   `setup-node@v6` + Node 22 ships npm 10.x; trusted-publisher *auto-detection* for
+   auth landed in **npm 11.5.1**. Pre-11.5.1 signs provenance via OIDC but does NOT
+   authenticate the publish via OIDC. *Fixed in #24 by installing `npm@^11.5.1`.*
+
+5. **Local `npm publish --provenance` failed: `Automatic provenance generation not
+   supported for provider: null`.** `--provenance` only works inside a recognized CI
+   OIDC provider. *Worked around by publishing locally without `--provenance`* — so
+   0.5.1 is the one version in the chain without a SLSA attestation.
+
+6. **A third-party reviewer bot (`hermes-reviewer`) reviewed the wrong PR** — it
+   resolved a different repo's PR #18 ("dark vibrant theme") and posted React/JSX
+   findings on our YAML-only PR. Ignored as a misconfigured bot; flagged to the user.
+
+## What I learned
+
+- **npm returns `404 PUT` for auth failures on writes, not `401`.** By design — it
+  avoids leaking package existence to unauthorized callers. So `404 Not Found` on
+  publish almost always means "bad/missing credentials," not "package doesn't exist."
+- **Provenance signing and publisher authentication are separate OIDC flows.** The
+  CLI can sign a provenance statement via OIDC (sigstore) while still failing to
+  *authenticate the publish* via OIDC. Seeing "Provenance statement published" in the
+  log does NOT mean auth succeeded.
+- **npm Trusted-Publishing auto-detection requires npm CLI ≥ 11.5.1** (GA 2025-07-31).
+  `actions/setup-node` ships whatever npm is bundled with the chosen Node — varies by
+  Node patch release, often older than 11.5.1. Pin npm explicitly for release jobs.
+- **Re-running a release-triggered workflow uses the tagged commit's YAML**, not
+  `main`. A workflow fix on `main` only takes effect on a *new* release event. This is
+  why we couldn't recover 0.5.0/0.5.1 by re-running — each needed a new tag.
+- **`--provenance` is CI-only.** Local publishes can't generate it (no OIDC provider),
+  so emergency local publishes lose the attestation for that version.
+- **GitHub artifacts with `retention-days: 1` are a recovery trap** — any re-run more
+  than a day later fails on download. Match retention to your realistic recovery window.
+
+## Decisions made
+
+- **Combined recovery strategy for the stuck release:** publish 0.5.1 locally (lands
+  today, no provenance) AND merge the CI fix (#24) so the *next* release publishes
+  cleanly with provenance restored. Avoided burning a v0.5.2 purely on plumbing.
+- **Accepted one provenance gap (0.5.1)** rather than cut yet another version. The
+  package bytes are identical; only the npm "verified provenance" badge is missing for
+  this one version.
+- **Pinned `npm@^11.5.1`, not `@latest`** (per Qodo review) — reproducible releases,
+  no surprise npm 12.x, still gets patch fixes. Logged `npm --version` for debugging.
+- **Title-doubling for BM25 field weighting** instead of full BM25F — documented
+  honestly as a ~1–2% length-norm distortion that's uniform across the corpus.
+- **Deferred Porter stemmer** — logged as conditional task 0004; only act on it if
+  recall complaints actually surface.
+
+## Next session
+
+- Consider pinning `npm@^11.5.1` in the **build** job too (not just `publish-npm`),
+  so `npm pack` and `npm publish` use the same CLI — consistency + closes any subtle
+  pack/publish drift.

--- a/30-evergreen/npm Trusted Publishing from GitHub Actions.md
+++ b/30-evergreen/npm Trusted Publishing from GitHub Actions.md
@@ -1,0 +1,85 @@
+---
+title: "npm Trusted Publishing from GitHub Actions"
+tags:
+  - evergreen
+  - ci
+  - npm
+  - release
+  - oidc
+---
+
+# npm Trusted Publishing from GitHub Actions
+
+Publishing an npm package from CI via OIDC instead of a long-lived `NPM_TOKEN`.
+The trust is configured once on npmjs.com and the GitHub Actions OIDC token both
+**signs provenance** and **authenticates the publish**. No secret to rotate.
+
+This note exists because getting it working end-to-end on [[vault-tasks]] took
+three failed publish attempts, each with the same misleading error and a
+different root cause.
+
+## The three preconditions
+
+All three must hold or the publish fails:
+
+1. **npm-side trust configured** — npmjs.com → package → Settings → Trusted
+   Publishers → add the org/user, repo, and **workflow filename** (e.g.
+   `publish.yml`), environment left blank if the job doesn't use one.
+2. **`id-token: write` permission** on the publishing job (mints the OIDC token).
+3. **npm CLI ≥ 11.5.1** — the version where trusted-publisher *auto-detection for
+   authentication* landed (GA 2025-07-31). This is the easy one to miss.
+
+## The npm-CLI-version trap
+
+`actions/setup-node` ships whatever npm is bundled with the chosen Node version —
+Node 22 was still on npm 10.x. **Pre-11.5.1, the CLI signs provenance via OIDC but
+does NOT authenticate the publish via OIDC.** So you see this in the log and assume
+success is imminent:
+
+```
+npm notice publish Signed provenance statement ...
+npm notice publish Provenance statement published to transparency log: ...
+```
+
+...and then it fails anyway. **Provenance signing and publisher authentication are
+two separate OIDC flows.** Seeing the provenance line does not mean auth worked.
+
+Fix: pin npm before the publish step.
+
+```yaml
+- name: Upgrade npm for Trusted Publishing
+  run: |
+    npm install -g 'npm@^11.5.1'
+    npm --version
+```
+
+Pin a range (`^11.5.1`), not `@latest` — release pipelines should be reproducible.
+
+## The misleading 404
+
+A failed *authenticated write* returns **`404 Not Found - PUT .../<pkg>`**, not
+401. npm does this deliberately so it can't be used to probe which private packages
+exist. So on a publish step, `404` almost always means **bad/missing/insufficient
+credentials**, not "the package doesn't exist." Don't chase the literal message.
+
+## `--provenance` is CI-only
+
+`npm publish --provenance` only works inside a recognized CI OIDC provider. A local
+`npm publish --provenance` errors with `Automatic provenance generation not
+supported for provider: null`. An emergency local publish must drop the flag,
+leaving that one version without a SLSA attestation.
+
+## Re-runs use the tagged commit's workflow
+
+Fixing the workflow on `main` does **not** unblock a release that already failed.
+Re-running a `release`-triggered workflow uses the YAML **at the tagged commit**,
+not current `main`. Recovery requires cutting a *new* tag/release, or publishing
+that version by hand.
+
+## Related
+
+- [[vault-tasks]] — where this was learned, across PRs #18 / #22 / #24
+- [[2026-06-10 0245 BM25 Search Module and npm Trusted-Publishing Saga]] — the
+  session build log with the full failure chain
+- PyPI Trusted Publishing follows the same OIDC model and was already working in the
+  same `publish.yml` — useful as a known-good reference when debugging the npm side

--- a/30-evergreen/npm Trusted Publishing from GitHub Actions.md
+++ b/30-evergreen/npm Trusted Publishing from GitHub Actions.md
@@ -109,4 +109,4 @@ that version by hand.
 - [[2026-06-10 0245 BM25 Search Module and npm Trusted-Publishing Saga]] — the
   session build log with the full failure chain
 - PyPI Trusted Publishing follows the same OIDC model and was already working in the
-  same `publish.yml` — useful as a known-good reference when debugging the npm side
+  same `publish.yml` — useful as a known-good reference when debugging the npm side.

--- a/30-evergreen/npm Trusted Publishing from GitHub Actions.md
+++ b/30-evergreen/npm Trusted Publishing from GitHub Actions.md
@@ -51,8 +51,11 @@ All three must hold or the publish fails:
    Publishers → add the org/user, repo, and **workflow filename** (e.g.
    `publish.yml`), environment left blank if the job doesn't use one.
 2. **`id-token: write` permission** on the publishing job (mints the OIDC token).
-3. **npm CLI ≥ 11.5.1** — the version where trusted-publisher *auto-detection for
-   authentication* landed (GA 2025-07-31). This is the easy one to miss.
+3. **npm CLI ≥ 11.5.1** — the recommended minimum for trusted-publisher
+   *auto-detection of OIDC authentication* (the flow reached general
+   availability on 2025-07-31; the capability first shipped slightly earlier in
+   the 11.5.x line). Older CLIs sign provenance but do NOT auto-authenticate the
+   publish. This is the easy precondition to miss.
 
 ## The npm-CLI-version trap
 

--- a/30-evergreen/npm Trusted Publishing from GitHub Actions.md
+++ b/30-evergreen/npm Trusted Publishing from GitHub Actions.md
@@ -51,11 +51,10 @@ All three must hold or the publish fails:
    Publishers → add the org/user, repo, and **workflow filename** (e.g.
    `publish.yml`), environment left blank if the job doesn't use one.
 2. **`id-token: write` permission** on the publishing job (mints the OIDC token).
-3. **npm CLI ≥ 11.5.1** — the recommended minimum for trusted-publisher
-   *auto-detection of OIDC authentication* (the flow reached general
-   availability on 2025-07-31; the capability first shipped slightly earlier in
-   the 11.5.x line). Older CLIs sign provenance but do NOT auto-authenticate the
-   publish. This is the easy precondition to miss.
+3. **npm CLI ≥ 11.5.1** — the version that introduced trusted-publisher
+   *auto-detection of OIDC authentication* (npm Trusted Publishing reached
+   general availability on 2025-07-31). Older CLIs sign provenance but do NOT
+   auto-authenticate the publish. This is the easy precondition to miss.
 
 ## The npm-CLI-version trap
 

--- a/30-evergreen/npm Trusted Publishing from GitHub Actions.md
+++ b/30-evergreen/npm Trusted Publishing from GitHub Actions.md
@@ -18,6 +18,31 @@ This note exists because getting it working end-to-end on [[vault-tasks]] took
 three failed publish attempts, each with the same misleading error and a
 different root cause.
 
+```mermaid
+sequenceDiagram
+    participant GHA as GitHub Actions job
+    participant OIDC as GitHub OIDC provider
+    participant CLI as npm CLI (>=11.5.1)
+    participant Reg as npm registry
+    participant Log as Sigstore transparency log
+
+    Note over GHA,CLI: job needs id-token: write
+    GHA->>CLI: npm publish --provenance
+    CLI->>OIDC: request id-token
+    OIDC-->>CLI: signed OIDC JWT
+    CLI->>Log: sign + publish provenance statement
+    Note right of CLI: succeeds even if auth later fails
+    CLI->>Reg: exchange OIDC token for publish creds
+    Note right of Reg: matches Trusted Publisher<br/>(repo + workflow filename)?
+    alt CLI < 11.5.1 OR no trust config OR no token
+        Reg-->>CLI: 404 PUT (unauthenticated write)
+    else all three preconditions hold
+        Reg-->>CLI: short-lived scoped publish token
+        CLI->>Reg: PUT package (authenticated)
+        Reg-->>CLI: 200 OK
+    end
+```
+
 ## The three preconditions
 
 All three must hold or the publish fails:

--- a/30-evergreen/npm Trusted Publishing from GitHub Actions.md
+++ b/30-evergreen/npm Trusted Publishing from GitHub Actions.md
@@ -61,7 +61,7 @@ Node 22 was still on npm 10.x. **Pre-11.5.1, the CLI signs provenance via OIDC b
 does NOT authenticate the publish via OIDC.** So you see this in the log and assume
 success is imminent:
 
-```
+```text
 npm notice publish Signed provenance statement ...
 npm notice publish Provenance statement published to transparency log: ...
 ```

--- a/50-backlog/0005-pin-npm-version-in-build-job-for-pack-publish-consistency.md
+++ b/50-backlog/0005-pin-npm-version-in-build-job-for-pack-publish-consistency.md
@@ -1,0 +1,30 @@
+---
+title: Pin npm@^11.5.1 in the build job too for pack/publish consistency
+status: open
+priority: medium
+tags:
+  - ci
+  - release
+created: 2026-06-10
+source: "[[2026-06-10 0245 BM25 Search Module and npm Trusted-Publishing Saga]]"
+---
+# Pin npm@^11.5.1 in the build job too for pack/publish consistency
+
+PR #24 added `npm install -g 'npm@^11.5.1'` to the `publish-npm` job so trusted
+publishing's OIDC auto-detection works. But the `build` job (which runs `npm pack`
+to produce the tarball that `publish-npm` later uploads) still uses whatever npm
+`actions/setup-node@v6` + Node 22 bundles (currently 10.x).
+
+So the tarball is **packed** with one npm version and **published** with another.
+This works today, but it's a latent inconsistency:
+
+- Any future `npm pack` behavior change (file inclusion, `package.json`
+  normalization, integrity hashing) would silently differ between the two jobs.
+- Debugging is harder when the two halves of the release use different CLIs.
+
+Consider adding the same `npm install -g 'npm@^11.5.1'` step (or a shared composite
+action / reusable step) to the `build` job in `.github/workflows/publish.yml`, so
+pack and publish run on the same pinned npm.
+
+Low urgency — purely defensive consistency, not a known bug. See
+`[[npm Trusted Publishing from GitHub Actions]]` for the surrounding context.


### PR DESCRIPTION
Session documentation for the 0.5.x release cycle. No code changes.

## Contents

- **`01-journal/2026/2026-06-10 0245 ...`** — build log covering the BM25 search
  module (#15), its 16-finding hostile self-review, and the four-PR release
  debugging chain (#18 → #22 → #24).
- **`30-evergreen/npm Trusted Publishing from GitHub Actions.md`** — transferable
  knowledge distilled from the saga:
  - npm CLI ≥ 11.5.1 needed for trusted-publisher *auth* auto-detection (Node 22
    ships 10.x)
  - provenance signing and publisher auth are **separate** OIDC flows — seeing the
    provenance log line doesn't mean auth succeeded
  - `404 PUT` on publish means bad credentials, not missing package
  - `--provenance` is CI-only
  - re-running a release workflow uses the **tagged commit's** YAML, not `main`
- **`50-backlog/0005`** — consider pinning npm in the `build` job too, so `npm pack`
  and `npm publish` run on the same CLI version.

## Note on conventions

`vt new` couldn't be used for the backlog task: this repo stores tasks in
`50-backlog/` but there's no `.vault-tasks.toml`, so the CLI defaults to `backlog/`.
Wrote `0005` directly to match the existing `000N` convention. Possibly worth adding
a `.vault-tasks.toml` so the dogfooded CLI works in its own repo (not in scope here).

---
_Generated by [Claude Code](https://claude.ai/code/session_011YtPtRVA4aAqNEzziLd2bc)_