### PR TITLE
Adopt Biome for formatting + linting, gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,24 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint & format check (Biome)
+        run: npx biome ci .
+
   build-and-test:
     runs-on: ubuntu-latest
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["src/**/*.ts", "scripts/**/*.mjs", "*.json", "*.mjs"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "es5"
+    }
+  },
+  "json": {
+    "formatter": {
+      "enabled": true
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "off"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "useLiteralKeys": "off"
+      },
+      "style": {
+        "useTemplate": "off",
+        "noNonNullAssertion": "off"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "vault-tasks",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vault-tasks",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "bin": {
         "vault-tasks": "dist/cli.js",
         "vt": "dist/cli.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.16",
         "@types/node": "^25.5.0",
         "typescript": "^5.8.0"
       },
@@ -21,6 +22,169 @@
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^3.0.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.16.tgz",
+      "integrity": "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.16",
+        "@biomejs/cli-darwin-x64": "2.4.16",
+        "@biomejs/cli-linux-arm64": "2.4.16",
+        "@biomejs/cli-linux-arm64-musl": "2.4.16",
+        "@biomejs/cli-linux-x64": "2.4.16",
+        "@biomejs/cli-linux-x64-musl": "2.4.16",
+        "@biomejs/cli-win32-arm64": "2.4.16",
+        "@biomejs/cli-win32-x64": "2.4.16"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz",
+      "integrity": "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz",
+      "integrity": "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz",
+      "integrity": "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz",
+      "integrity": "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz",
+      "integrity": "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz",
+      "integrity": "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz",
+      "integrity": "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz",
+      "integrity": "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "build": "tsc",
     "build:wheel": "tsc && node scripts/build-wheel.mjs",
     "test": "node --test dist/tests/*.test.js",
+    "format": "biome format --write .",
+    "lint": "biome lint .",
+    "check": "biome check .",
+    "check:fix": "biome check --write .",
     "prepublishOnly": "npm run build && npm test"
   },
   "keywords": [
@@ -56,6 +60,7 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.16",
     "@types/node": "^25.5.0",
     "typescript": "^5.8.0"
   },

--- a/scripts/build-wheel.mjs
+++ b/scripts/build-wheel.mjs
@@ -36,7 +36,9 @@ if (!existsSync(templatesDir)) {
   fail(`templates/ not found at ${templatesDir}.`);
 }
 if (!existsSync(pythonPkgDir)) {
-  fail(`python/vault_tasks/ not found at ${pythonPkgDir}. Did you check out the wheel scaffolding?`);
+  fail(
+    `python/vault_tasks/ not found at ${pythonPkgDir}. Did you check out the wheel scaffolding?`
+  );
 }
 
 // Version source: VAULT_TASKS_VERSION_OVERRIDE env var (used by the TestPyPI

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -172,7 +172,11 @@ function isFlag(arg: string): boolean {
   return false;
 }
 
-function parseArgs(argv: string[]): { command: string; args: Record<string, string | boolean>; positional: string[] } {
+function parseArgs(argv: string[]): {
+  command: string;
+  args: Record<string, string | boolean>;
+  positional: string[];
+} {
   const command = argv[0] ?? "";
   const args: Record<string, string | boolean> = {};
   const positional: string[] = [];
@@ -203,7 +207,7 @@ function parseArgs(argv: string[]): { command: string; args: Record<string, stri
         } else {
           throw new Error(
             `Flag --${key} is boolean; expected true/false/1/0 but got '${rawValue}'. ` +
-            `Either pass --${key} on its own, or use --${key}=true / --${key}=false.`
+              `Either pass --${key} on its own, or use --${key}=true / --${key}=false.`
           );
         }
       } else {
@@ -284,7 +288,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  let config;
+  let config: ReturnType<typeof loadConfig>;
   try {
     config = loadConfig();
   } catch (err) {
@@ -307,7 +311,9 @@ async function main(): Promise<void> {
 
       case "new":
         if (!positional[0]) {
-          console.error("Usage: vt new <title> [--priority P] [--tags t1,t2] [--source S] [--commit] [--body TEXT|--body-file PATH]");
+          console.error(
+            "Usage: vt new <title> [--priority P] [--tags t1,t2] [--source S] [--commit] [--body TEXT|--body-file PATH]"
+          );
           process.exitCode = 1;
           return;
         }
@@ -338,8 +344,8 @@ async function main(): Promise<void> {
         if (!positional[0] && args["like"] === undefined) {
           console.error(
             "Usage:\n" +
-            "  vt search <keyword> [--all] [--mode keyword|bm25|semantic|hybrid] [--limit N]\n" +
-            "  vt search --like <id> --mode bm25|semantic|hybrid [--all] [--limit N]"
+              "  vt search <keyword> [--all] [--mode keyword|bm25|semantic|hybrid] [--limit N]\n" +
+              "  vt search --like <id> --mode bm25|semantic|hybrid [--all] [--limit N]"
           );
           process.exitCode = 1;
           return;
@@ -390,7 +396,9 @@ async function main(): Promise<void> {
 
       case "edit":
         if (!positional[0]) {
-          console.error("Usage: vt edit <id-or-substring> [--status S] [--priority P] [--tags t1,t2]");
+          console.error(
+            "Usage: vt edit <id-or-substring> [--status S] [--priority P] [--tags t1,t2]"
+          );
           process.exitCode = 1;
           return;
         }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,11 +1,4 @@
-import {
-  closeSync,
-  existsSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { generateDefaultConfig, loadConfig } from "../config.js";
 

--- a/src/commands/install-skills.ts
+++ b/src/commands/install-skills.ts
@@ -1,11 +1,4 @@
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Config } from "../config.js";
@@ -19,7 +12,7 @@ const __dirname = dirname(__filename);
 function getTemplatesDir(): string {
   const envOverride = process.env.VAULT_TASKS_TEMPLATES_DIR;
   if (envOverride) {
-    let stat;
+    let stat: ReturnType<typeof statSync>;
     try {
       stat = statSync(envOverride);
     } catch {
@@ -38,9 +31,7 @@ function getTemplatesDir(): string {
   const packageRoot = resolve(__dirname, "..", "..");
   const templatesDir = join(packageRoot, "templates");
   if (!existsSync(templatesDir)) {
-    throw new Error(
-      "Cannot find templates directory. Is the package installed correctly?"
-    );
+    throw new Error("Cannot find templates directory. Is the package installed correctly?");
   }
   return templatesDir;
 }
@@ -133,7 +124,9 @@ export function cmdInstallSkills(
   if (!args.install) {
     console.log("Usage: vt install-skills --install  Install all skills, rules, and templates");
     console.log("       vt install-skills --list   List available templates");
-    console.log("       vt install-skills --update Overwrite existing base files (preserves .local.md)");
+    console.log(
+      "       vt install-skills --update Overwrite existing base files (preserves .local.md)"
+    );
     return;
   }
 
@@ -161,9 +154,7 @@ export function cmdInstallSkills(
     installed++;
   }
 
-  console.log(
-    `\n${installed} installed, ${skipped} skipped (already exist).`
-  );
+  console.log(`\n${installed} installed, ${skipped} skipped (already exist).`);
 
   if (installed > 0) {
     console.log("\nNote: You can customize any skill by creating a SKILL.local.md");

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,10 +1,6 @@
 import type { Config } from "../config.js";
 import { lintVault } from "../lint/index.js";
-import {
-  formatHumanReport,
-  formatJsonReport,
-  formatSummaryLine,
-} from "../lint/report.js";
+import { formatHumanReport, formatJsonReport, formatSummaryLine } from "../lint/report.js";
 import type { CheckName } from "../lint/types.js";
 
 const VALID_CHECKS: ReadonlySet<CheckName> = new Set(["broken", "orphans", "stale", "drift"]);
@@ -22,22 +18,20 @@ export function cmdLint(config: Config, args: LintCmdArgs): void {
   if (args.only !== undefined) {
     const v = args.only.toLowerCase();
     if (!VALID_CHECKS.has(v as CheckName)) {
-      console.error(
-        `Error: --only must be one of broken|orphans|stale|drift (got '${args.only}')`
-      );
+      console.error(`Error: --only must be one of broken|orphans|stale|drift (got '${args.only}')`);
       process.exitCode = 2;
       return;
     }
     only = v as CheckName;
   }
 
-  if (args.scope !== undefined && args.scope.includes("..")) {
+  if (args.scope?.includes("..")) {
     console.error("Error: --scope must be inside the vault (no '..')");
     process.exitCode = 2;
     return;
   }
 
-  let report;
+  let report: ReturnType<typeof lintVault>;
   try {
     report = lintVault(config, {
       only,

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -74,9 +74,7 @@ export function cmdNew(
   }
 
   const store = new TaskStore(config);
-  const tags = args.tags
-    ? args.tags.split(",").map((t) => t.trim())
-    : [];
+  const tags = args.tags ? args.tags.split(",").map((t) => t.trim()) : [];
 
   // Check for similar existing tasks before creating. Bounded by
   // `dedupeScanLimit` so large archives don't turn every `vt new` into an

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,5 +1,10 @@
 import type { Config } from "../config.js";
-import { formatSearchHits, formatTaskTable, sanitizeForDisplay, sortByPriority } from "../output.js";
+import {
+  formatSearchHits,
+  formatTaskTable,
+  sanitizeForDisplay,
+  sortByPriority,
+} from "../output.js";
 import { searchTasks, similarTasks } from "../search/index.js";
 import type { SearchMode } from "../search/types.js";
 import { TaskStore } from "../store.js";
@@ -29,7 +34,7 @@ export async function cmdSearch(config: Config, args: SearchArgs): Promise<void>
   if (args.like !== undefined && args.keyword !== undefined) {
     throw new Error(
       "--like and a positional <keyword> cannot be combined. " +
-      "Use --like <id> for similarity search, or <keyword> for query search."
+        "Use --like <id> for similarity search, or <keyword> for query search."
     );
   }
 
@@ -40,8 +45,8 @@ export async function cmdSearch(config: Config, args: SearchArgs): Promise<void>
     if (mode === "keyword") {
       throw new Error(
         `--like requires --mode bm25, semantic, or hybrid. Keyword mode does substring ` +
-        `matching, not task similarity. ` +
-        `Try: vt search --like '${sanitizeForDisplay(args.like)}' --mode bm25`
+          `matching, not task similarity. ` +
+          `Try: vt search --like '${sanitizeForDisplay(args.like)}' --mode bm25`
       );
     }
     const target = store.findIncludingArchive(args.like);
@@ -61,8 +66,8 @@ export async function cmdSearch(config: Config, args: SearchArgs): Promise<void>
   if (!args.keyword) {
     throw new Error(
       "Usage:\n" +
-      "  vt search <keyword> [--all] [--mode keyword|bm25|semantic|hybrid] [--limit N]\n" +
-      "  vt search --like <id> --mode bm25|semantic|hybrid [--all] [--limit N]"
+        "  vt search <keyword> [--all] [--mode keyword|bm25|semantic|hybrid] [--limit N]\n" +
+        "  vt search --like <id> --mode bm25|semantic|hybrid [--all] [--limit N]"
     );
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,7 +197,7 @@ export function findConfigFile(startDir: string = process.cwd()): string | null 
 export function parseToml(text: string): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   let currentSection: Record<string, unknown> = result;
-  let currentSectionPath: string[] = [];
+  let _currentSectionPath: string[] = [];
 
   for (const rawLine of text.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -209,7 +209,7 @@ export function parseToml(text: string): Record<string, unknown> {
     const sectionMatch = line.match(/^\[([^\]]+)\]$/);
     if (sectionMatch) {
       const parts = sectionMatch[1].split(".");
-      currentSectionPath = parts;
+      _currentSectionPath = parts;
 
       // Navigate/create nested objects
       let target = result;
@@ -247,8 +247,8 @@ export function parseToml(text: string): Record<string, unknown> {
         if (closeBracket < 0) {
           throw new Error(
             `Multi-line arrays are not supported. ` +
-            `Key "${key}" has an opening "[" but no closing "]" on the same line. ` +
-            `Please use single-line arrays, e.g.: ${key} = ["a", "b"]`
+              `Key "${key}" has an opening "[" but no closing "]" on the same line. ` +
+              `Please use single-line arrays, e.g.: ${key} = ["a", "b"]`
           );
         }
         rawValue = rawValue.slice(0, closeBracket + 1).trim();
@@ -267,9 +267,7 @@ export function parseToml(text: string): Record<string, unknown> {
         if (inner === "") {
           value = [];
         } else {
-          value = inner
-            .split(",")
-            .map((v) => v.trim().replace(/^["']|["']$/g, ""));
+          value = inner.split(",").map((v) => v.trim().replace(/^["']|["']$/g, ""));
         }
       }
       // Boolean
@@ -383,11 +381,14 @@ export function loadConfig(startDir?: string): Config {
   let idStrategy: IdStrategy;
   let inferredPadWidth: number | null = null;
   if (rawStrategy !== undefined) {
-    if (typeof rawStrategy !== "string" || !(ID_STRATEGIES as readonly string[]).includes(rawStrategy)) {
+    if (
+      typeof rawStrategy !== "string" ||
+      !(ID_STRATEGIES as readonly string[]).includes(rawStrategy)
+    ) {
       throw new Error(
         `Invalid [id] strategy: ${JSON.stringify(rawStrategy)}. ` +
-        `Must be one of: ${ID_STRATEGIES.join(", ")}. ` +
-        `Edit ${configFile} to fix.`
+          `Must be one of: ${ID_STRATEGIES.join(", ")}. ` +
+          `Edit ${configFile} to fix.`
       );
     }
     idStrategy = rawStrategy as IdStrategy;
@@ -411,7 +412,7 @@ export function loadConfig(startDir?: string): Config {
     if (!Number.isFinite(n) || n < 0 || n > 1) {
       throw new Error(
         `Invalid [task] dedupe_threshold: ${JSON.stringify(rawThreshold)}. ` +
-        `Must be a number between 0 and 1.`
+          `Must be a number between 0 and 1.`
       );
     }
     dedupeThreshold = n;
@@ -424,7 +425,7 @@ export function loadConfig(startDir?: string): Config {
     if (!Number.isInteger(n) || n < 0) {
       throw new Error(
         `Invalid [task] dedupe_scan_limit: ${JSON.stringify(rawScanLimit)}. ` +
-        `Must be a non-negative integer.`
+          `Must be a non-negative integer.`
       );
     }
     dedupeScanLimit = n;
@@ -446,7 +447,9 @@ export function loadConfig(startDir?: string): Config {
     idStrategy,
     padWidth:
       (id["pad_width"] as number) ??
-      (inferredPadWidth !== null ? Math.max(inferredPadWidth, DEFAULTS.padWidth) : DEFAULTS.padWidth),
+      (inferredPadWidth !== null
+        ? Math.max(inferredPadWidth, DEFAULTS.padWidth)
+        : DEFAULTS.padWidth),
     slugMaxLength: (slug["max_length"] as number) ?? DEFAULTS.slugMaxLength,
     dedupeThreshold,
     dedupeScanLimit,
@@ -471,7 +474,7 @@ function mergeSearchConfig(search: Record<string, unknown>): SearchConfig {
     ) {
       throw new Error(
         `Invalid [search] embedding_provider: ${JSON.stringify(rawProvider)}. ` +
-        `Must be one of: ${EMBEDDING_PROVIDERS.join(", ")}.`
+          `Must be one of: ${EMBEDDING_PROVIDERS.join(", ")}.`
       );
     }
     embeddingProvider = rawProvider as EmbeddingProvider;
@@ -495,7 +498,7 @@ function mergeSearchConfig(search: Record<string, unknown>): SearchConfig {
     if (!Number.isSafeInteger(n) || n <= 0) {
       throw new Error(
         `Invalid [search] embedding_dimensions: ${JSON.stringify(rawDimensions)}. ` +
-        `Must be a positive integer.`
+          `Must be a positive integer.`
       );
     }
     embeddingDimensions = n;
@@ -519,7 +522,7 @@ function mergeSearchConfig(search: Record<string, unknown>): SearchConfig {
     if (typeof rawKeyEnv !== "string") {
       throw new Error(
         `Invalid [search] embedding_api_key_env: ${JSON.stringify(rawKeyEnv)}. ` +
-        `Must be the NAME of an environment variable (not the key itself).`
+          `Must be the NAME of an environment variable (not the key itself).`
       );
     }
     embeddingApiKeyEnv = rawKeyEnv.trim();
@@ -558,7 +561,7 @@ function mergeLintConfig(
     if (!Number.isFinite(n) || n < 0 || n > 1) {
       throw new Error(
         `Invalid [lint] suggestion_threshold: ${JSON.stringify(rawThreshold)}. ` +
-        `Must be a number between 0 and 1.`
+          `Must be a number between 0 and 1.`
       );
     }
     suggestionThreshold = n;
@@ -586,7 +589,7 @@ function mergeLintConfig(
     } catch (err) {
       throw new Error(
         `Invalid [lint] template_patterns[${i}]: ${JSON.stringify(p)}. ` +
-        `${(err as Error).message}`
+          `${(err as Error).message}`
       );
     }
   });
@@ -594,8 +597,14 @@ function mergeLintConfig(
   return {
     referenceDir,
     referenceExclude: asStringArray(lint["reference_exclude"], DEFAULT_LINT.referenceExclude),
-    templateSourceDirs: asStringArray(lint["template_source_dirs"], DEFAULT_LINT.templateSourceDirs),
-    templateSourceFiles: asStringArray(lint["template_source_files"], DEFAULT_LINT.templateSourceFiles),
+    templateSourceDirs: asStringArray(
+      lint["template_source_dirs"],
+      DEFAULT_LINT.templateSourceDirs
+    ),
+    templateSourceFiles: asStringArray(
+      lint["template_source_files"],
+      DEFAULT_LINT.templateSourceFiles
+    ),
     templatePatterns,
     skipDirs: asStringArray(lint["skip_dirs"], DEFAULT_LINT.skipDirs),
     evergreenConventions: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,7 +197,6 @@ export function findConfigFile(startDir: string = process.cwd()): string | null 
 export function parseToml(text: string): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   let currentSection: Record<string, unknown> = result;
-  let _currentSectionPath: string[] = [];
 
   for (const rawLine of text.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -209,7 +208,6 @@ export function parseToml(text: string): Record<string, unknown> {
     const sectionMatch = line.match(/^\[([^\]]+)\]$/);
     if (sectionMatch) {
       const parts = sectionMatch[1].split(".");
-      _currentSectionPath = parts;
 
       // Navigate/create nested objects
       let target = result;

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -10,13 +10,31 @@
  */
 
 /** Characters that require double-quoting in a YAML value. */
-const YAML_SPECIAL = /[:#{}\[\]"'`|>!&*@,?\\]/;
+const YAML_SPECIAL = /[:#{}[\]"'`|>!&*@,?\\]/;
 
 /** YAML boolean/null literals that must be quoted to remain strings. */
 const YAML_RESERVED = new Set([
-  "true", "false", "null", "yes", "no", "on", "off",
-  "True", "False", "Null", "Yes", "No", "On", "Off",
-  "TRUE", "FALSE", "NULL", "YES", "NO", "ON", "OFF",
+  "true",
+  "false",
+  "null",
+  "yes",
+  "no",
+  "on",
+  "off",
+  "True",
+  "False",
+  "Null",
+  "Yes",
+  "No",
+  "On",
+  "Off",
+  "TRUE",
+  "FALSE",
+  "NULL",
+  "YES",
+  "NO",
+  "ON",
+  "OFF",
 ]);
 
 /**
@@ -53,11 +71,16 @@ function unquoteValue(raw: string): string {
   if (raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')) {
     return raw.slice(1, -1).replace(/\\(.)/g, (_: string, ch: string) => {
       switch (ch) {
-        case "n": return "\n";
-        case "t": return "\t";
-        case '"': return '"';
-        case "\\": return "\\";
-        default: return ch;
+        case "n":
+          return "\n";
+        case "t":
+          return "\t";
+        case '"':
+          return '"';
+        case "\\":
+          return "\\";
+        default:
+          return ch;
       }
     });
   }
@@ -67,9 +90,7 @@ function unquoteValue(raw: string): string {
   return raw;
 }
 
-export function parseFrontmatter(
-  text: string
-): { meta: Record<string, unknown>; body: string } {
+export function parseFrontmatter(text: string): { meta: Record<string, unknown>; body: string } {
   // Normalize CRLF → LF
   const normalized = text.replace(/\r\n/g, "\n");
 
@@ -108,11 +129,7 @@ export function parseFrontmatter(
     // continuation like `title: Foo\n  - bar` would silently convert the
     // string scalar into a list and drop the first line.
     const listMatch = line.match(/^\s*-\s+(.+)$/);
-    if (
-      listMatch &&
-      currentKey !== null &&
-      (currentList !== null || meta[currentKey] === "")
-    ) {
+    if (listMatch && currentKey !== null && (currentList !== null || meta[currentKey] === "")) {
       if (currentList === null) {
         currentList = [];
       }
@@ -145,7 +162,7 @@ export function parseFrontmatter(
     }
 
     // Key-value pair — allow dots, hyphens, underscores in keys
-    const kvMatch = line.match(/^([\w][\w.\-]*):\s*(.*)$/);
+    const kvMatch = line.match(/^([\w][\w.-]*):\s*(.*)$/);
     if (kvMatch) {
       if (currentList !== null) {
         currentList = null;
@@ -164,9 +181,7 @@ export function parseFrontmatter(
       // Inline list: [tag1, tag2] — but not wikilinks [[like this]]
       const inlineList = rawValue.match(/^\[(.+)\]$/);
       if (inlineList && !rawValue.startsWith("[[")) {
-        const items = inlineList[1]
-          .split(",")
-          .map((v) => unquoteValue(v.trim()));
+        const items = inlineList[1].split(",").map((v) => unquoteValue(v.trim()));
         meta[currentKey] = items;
         currentList = items;
       } else if (rawValue) {
@@ -182,10 +197,7 @@ export function parseFrontmatter(
   return { meta, body };
 }
 
-export function writeFrontmatter(
-  meta: Record<string, unknown>,
-  body: string
-): string {
+export function writeFrontmatter(meta: Record<string, unknown>, body: string): string {
   const lines: string[] = ["---"];
 
   for (const [key, value] of Object.entries(meta)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,5 +43,12 @@ export type {
 export type { SearchHit, SearchMode, SearchOptions } from "./search/types.js";
 export type { SearchConfig, EmbeddingProvider } from "./config.js";
 export { EMBEDDING_PROVIDERS } from "./config.js";
-export { searchTasks, similarTasks, BM25Index, VectorIndex, EmbedCache, createEmbedder } from "./search/index.js";
+export {
+  searchTasks,
+  similarTasks,
+  BM25Index,
+  VectorIndex,
+  EmbedCache,
+  createEmbedder,
+} from "./search/index.js";
 export type { Embedder } from "./search/index.js";

--- a/src/lint/checks/broken.ts
+++ b/src/lint/checks/broken.ts
@@ -10,10 +10,7 @@
 import type { ResolutionIndex, BrokenEntry, WikiLink } from "../types.js";
 import { resolveTarget } from "../resolve.js";
 
-export function findBrokenLinks(
-  links: WikiLink[],
-  index: ResolutionIndex
-): BrokenEntry[] {
+export function findBrokenLinks(links: WikiLink[], index: ResolutionIndex): BrokenEntry[] {
   const buckets = new Map<string, BrokenEntry>();
 
   for (const link of links) {

--- a/src/lint/checks/stale.ts
+++ b/src/lint/checks/stale.ts
@@ -37,10 +37,7 @@ export function findStaleReferences(
       if (!trimmed) return false;
       // Match the pattern as either a leading subdir (relative to the
       // reference root) or anywhere in the path.
-      return (
-        f.relPath.includes(`/${trimmed}/`) ||
-        f.relPath.startsWith(`${dirPrefix}/${trimmed}/`)
-      );
+      return f.relPath.includes(`/${trimmed}/`) || f.relPath.startsWith(`${dirPrefix}/${trimmed}/`);
     });
     if (excluded) continue;
 

--- a/src/lint/collect.ts
+++ b/src/lint/collect.ts
@@ -76,7 +76,7 @@ export function walkMarkdown(
         continue;
       }
 
-      let st;
+      let st: ReturnType<typeof lstatSync>;
       try {
         st = lstatSync(abs);
       } catch {
@@ -146,7 +146,7 @@ export function readVaultFiles(
     const normalised = text.replace(/\r\n/g, "\n");
     const { meta, body } = parseFrontmatter(normalised);
     const hasFrontmatter = Object.keys(meta).length > 0 || normalised.startsWith("---\n");
-    const hasTagsField = Object.prototype.hasOwnProperty.call(meta, "tags");
+    const hasTagsField = Object.hasOwn(meta, "tags");
     const titleRaw = meta["title"];
     const title = typeof titleRaw === "string" && titleRaw.length > 0 ? titleRaw : null;
 
@@ -236,6 +236,7 @@ export function collectWikilinks(
       const cleaned = raw.replace(INLINE_CODE_RE, "");
       WIKILINK_RE.lastIndex = 0;
       let m: RegExpExecArray | null;
+      // biome-ignore lint/suspicious/noAssignInExpressions: canonical global-regex exec() iteration idiom
       while ((m = WIKILINK_RE.exec(cleaned)) !== null) {
         const target = stripTargetSuffixes(m[1]);
         if (!target) continue;

--- a/src/lint/index.ts
+++ b/src/lint/index.ts
@@ -43,7 +43,9 @@ function relPathPosix(p: string): string {
 
 function normaliseScope(scope: string | undefined): string | null {
   if (!scope) return null;
-  const cleaned = relPathPosix(scope).replace(/^\.\/+/, "").replace(/\/+$/, "");
+  const cleaned = relPathPosix(scope)
+    .replace(/^\.\/+/, "")
+    .replace(/\/+$/, "");
   return cleaned === "" ? null : cleaned;
 }
 
@@ -74,15 +76,12 @@ export function lintVault(config: Config, opts: LintOptions = {}): LintReport {
   const index = buildIndex(allFiles);
 
   for (const [key, paths] of index.collisions) {
-    onWarn(
-      `${paths.length} files share normalised key '${key}': ${paths.join(", ")}`
-    );
+    onWarn(`${paths.length} files share normalised key '${key}': ${paths.join(", ")}`);
   }
 
   const scope = normaliseScope(opts.scope);
-  const scopedFiles: VaultFile[] = scope === null
-    ? allFiles
-    : allFiles.filter((f) => inScope(f.relPath, scope));
+  const scopedFiles: VaultFile[] =
+    scope === null ? allFiles : allFiles.filter((f) => inScope(f.relPath, scope));
 
   const allLinks = collectWikilinks(
     allFiles,
@@ -91,9 +90,7 @@ export function lintVault(config: Config, opts: LintOptions = {}): LintReport {
     lint.templatePatterns
   );
 
-  const scopedLinks = scope === null
-    ? allLinks
-    : allLinks.filter((l) => inScope(l.source, scope));
+  const scopedLinks = scope === null ? allLinks : allLinks.filter((l) => inScope(l.source, scope));
 
   const inbound = buildInboundMap(allLinks, index);
 
@@ -106,21 +103,12 @@ export function lintVault(config: Config, opts: LintOptions = {}): LintReport {
   if (wantBroken && !opts.noSuggestions) {
     attachSuggestions(broken, index, lint.suggestionThreshold);
   }
-  const leverageFixes = wantBroken && !opts.noSuggestions
-    ? computeLeverageFixes(broken)
-    : [];
+  const leverageFixes = wantBroken && !opts.noSuggestions ? computeLeverageFixes(broken) : [];
 
-  const orphans = wantOrphans
-    ? findOrphanEvergreens(scopedFiles, inbound, evergreenDirRel)
-    : [];
+  const orphans = wantOrphans ? findOrphanEvergreens(scopedFiles, inbound, evergreenDirRel) : [];
 
   const stale = wantStale
-    ? findStaleReferences(
-        scopedFiles,
-        inbound,
-        referenceDirRel,
-        lint.referenceExclude
-      )
+    ? findStaleReferences(scopedFiles, inbound, referenceDirRel, lint.referenceExclude)
     : [];
 
   const drift = wantDrift
@@ -134,10 +122,7 @@ export function lintVault(config: Config, opts: LintOptions = {}): LintReport {
     drift: drift.length,
   };
   const hasIssues =
-    summary.broken > 0 ||
-    summary.orphans > 0 ||
-    summary.stale > 0 ||
-    summary.drift > 0;
+    summary.broken > 0 || summary.orphans > 0 || summary.stale > 0 || summary.drift > 0;
 
   return {
     broken,

--- a/src/lint/report.ts
+++ b/src/lint/report.ts
@@ -32,10 +32,11 @@ export function formatHumanReport(report: LintReport): string {
   if (report.leverageFixes.length > 0) {
     out.push(`=== HIGH-LEVERAGE FIXES (${report.leverageFixes.length}) ===`);
     for (const fix of report.leverageFixes) {
-      const aliasList = fix.aliases.length === 1
-        ? `[${fix.aliases[0]}]`
-        : `[${fix.aliases.join(", ")}]`;
-      out.push(`  ${fix.action}: aliases ${aliasList}  closes ${fix.closes} broken link${fix.closes === 1 ? "" : "s"}`);
+      const aliasList =
+        fix.aliases.length === 1 ? `[${fix.aliases[0]}]` : `[${fix.aliases.join(", ")}]`;
+      out.push(
+        `  ${fix.action}: aliases ${aliasList}  closes ${fix.closes} broken link${fix.closes === 1 ? "" : "s"}`
+      );
     }
     out.push("");
   }
@@ -48,7 +49,9 @@ export function formatHumanReport(report: LintReport): string {
         `    suggest: ${sugg.filePath}  (sim ${formatSimilarity(sugg.similarity)}, ${sugg.kind} "${sugg.candidate}")`
       );
       if (sugg.kind !== "alias") {
-        out.push(`      → adding \`aliases: [${sugg.proposedAlias}]\` to that file would close all ${entry.count}`);
+        out.push(
+          `      → adding \`aliases: [${sugg.proposedAlias}]\` to that file would close all ${entry.count}`
+        );
       }
     }
     const limit = MAX_LOCATIONS_PER_TARGET;

--- a/src/lint/resolve.ts
+++ b/src/lint/resolve.ts
@@ -129,10 +129,7 @@ export function buildIndex(files: VaultFile[]): ResolutionIndex {
  * the two apart by design. Ambiguous targets must be disambiguated by the
  * author before they have a defined meaning.
  */
-export function resolveTarget(
-  rawTarget: string,
-  index: ResolutionIndex
-): string | null {
+export function resolveTarget(rawTarget: string, index: ResolutionIndex): string | null {
   const target = stripTargetSuffixes(rawTarget);
   if (!target) return null;
 

--- a/src/lint/suggest.ts
+++ b/src/lint/suggest.ts
@@ -16,13 +16,7 @@
  */
 
 import { similarity } from "../similarity.js";
-import type {
-  BrokenEntry,
-  LeverageFix,
-  ResolutionIndex,
-  Suggestion,
-  VaultFile,
-} from "./types.js";
+import type { BrokenEntry, LeverageFix, ResolutionIndex, Suggestion, VaultFile } from "./types.js";
 
 interface Candidate {
   text: string;

--- a/src/output.ts
+++ b/src/output.ts
@@ -39,9 +39,8 @@ function displayStatus(s: string): string {
 //  - Convert \r, \n, \t to spaces so layout is preserved (rather than
 //    silently shortened) when content with line breaks is rendered.
 export function sanitizeForDisplay(s: string): string {
-  return s
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, "")
-    .replace(/[\r\n\t]/g, " ");
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping control bytes is the point — this is the terminal-injection defense
+  return s.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, "").replace(/[\r\n\t]/g, " ");
 }
 
 export function sortByPriority(tasks: Task[]): Task[] {
@@ -74,9 +73,7 @@ export function formatTaskTable(tasks: Task[]): string {
   return [header, divider, ...rows].join("\n");
 }
 
-export function formatStaleTable(
-  items: Array<{ task: Task; ageDays: number }>
-): string {
+export function formatStaleTable(items: Array<{ task: Task; ageDays: number }>): string {
   if (items.length === 0) return "No stale tasks found.";
 
   const maxIdLen = Math.max(4, ...items.map(({ task }) => task.id.length));

--- a/src/search/embed-cache.ts
+++ b/src/search/embed-cache.ts
@@ -1,5 +1,12 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join, relative } from "node:path";
 import type { Task } from "../task.js";
 import type { Embedder } from "./embeddings.js";
@@ -35,7 +42,7 @@ export class EmbedCache {
   private readonly cachePath: string;
 
   constructor(
-    private readonly vaultRoot: string,
+    vaultRoot: string,
     private readonly provider: string,
     private readonly model: string,
     private readonly expectedDim: number | null = null
@@ -126,7 +133,11 @@ export class EmbedCache {
     const file = parsed as Partial<CacheFile>;
     if (file.version !== CACHE_VERSION) return map;
     if (file.provider !== this.provider || file.model !== this.model) return map;
-    if (this.expectedDim !== null && file.dimensions != null && file.dimensions !== this.expectedDim) {
+    if (
+      this.expectedDim !== null &&
+      file.dimensions != null &&
+      file.dimensions !== this.expectedDim
+    ) {
       return map; // header disagrees with configured dims — discard
     }
     const entries = file.entries;

--- a/src/search/embeddings.ts
+++ b/src/search/embeddings.ts
@@ -138,14 +138,14 @@ export function createEmbedder(search: SearchConfig): Embedder {
     if (!envName) {
       throw new Error(
         `Provider '${provider}' needs an API key. Set [search] embedding_api_key_env ` +
-        `to the NAME of an environment variable holding the key.`
+          `to the NAME of an environment variable holding the key.`
       );
     }
     apiKey = process.env[envName] ?? "";
     if (!apiKey && spec.requiresKey) {
       throw new Error(
         `Provider '${provider}' needs an API key, but environment variable ` +
-        `$${envName} is empty or unset. Export it and retry.`
+          `$${envName} is empty or unset. Export it and retry.`
       );
     }
   }
@@ -182,7 +182,12 @@ async function embedInBatches(
   return out;
 }
 
-async function postJson(url: string, body: unknown, headers: Record<string, string>, spec: ProviderSpec): Promise<unknown> {
+async function postJson(
+  url: string,
+  body: unknown,
+  headers: Record<string, string>,
+  spec: ProviderSpec
+): Promise<unknown> {
   let res: Response;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -198,12 +203,12 @@ async function postJson(url: string, body: unknown, headers: Record<string, stri
     if (err instanceof Error && err.name === "AbortError") {
       throw new Error(
         `${spec.label} timed out after ${REQUEST_TIMEOUT_MS / 1000}s at ${url}${hint}. ` +
-        `Check the endpoint is reachable, or set [search] embedding_provider.`
+          `Check the endpoint is reachable, or set [search] embedding_provider.`
       );
     }
     throw new Error(
       `${spec.label} not reachable at ${url}${hint}, or set [search] embedding_provider. ` +
-      `(${(err as Error).message})`
+        `(${(err as Error).message})`
     );
   } finally {
     clearTimeout(timer);
@@ -217,7 +222,7 @@ async function postJson(url: string, body: unknown, headers: Record<string, stri
     }
     throw new Error(
       `${spec.label} embedding request failed: HTTP ${res.status} ${res.statusText}` +
-      `${detail ? ` — ${detail}` : ""}`
+        `${detail ? ` — ${detail}` : ""}`
     );
   }
   try {
@@ -230,7 +235,9 @@ async function postJson(url: string, body: unknown, headers: Record<string, stri
 /** Validate one vector from a server response. No `as` casts on wire data. */
 function coerceVector(value: unknown, provider: string, expectedDim: number | null): number[] {
   if (!Array.isArray(value) || value.length === 0) {
-    throw new Error(`Provider '${provider}' returned a malformed embedding (not a non-empty array).`);
+    throw new Error(
+      `Provider '${provider}' returned a malformed embedding (not a non-empty array).`
+    );
   }
   const vec = new Array<number>(value.length);
   for (let i = 0; i < value.length; i++) {
@@ -243,7 +250,7 @@ function coerceVector(value: unknown, provider: string, expectedDim: number | nu
   if (expectedDim !== null && vec.length !== expectedDim) {
     throw new Error(
       `Embedding dimension mismatch: model returned ${vec.length}, but [search] ` +
-      `embedding_dimensions is ${expectedDim}. Update or remove that setting.`
+        `embedding_dimensions is ${expectedDim}. Update or remove that setting.`
     );
   }
   return vec;
@@ -296,9 +303,10 @@ async function openAiEmbed(
       throw new Error(`${spec.label} response item ${pos} has no 'embedding'.`);
     }
     const rawIndex = (item as { index?: unknown }).index;
-    const idx = Number.isInteger(rawIndex) && (rawIndex as number) >= 0 && (rawIndex as number) < data.length
-      ? (rawIndex as number)
-      : pos;
+    const idx =
+      Number.isInteger(rawIndex) && (rawIndex as number) >= 0 && (rawIndex as number) < data.length
+        ? (rawIndex as number)
+        : pos;
     out[idx] = coerceVector((item as { embedding: unknown }).embedding, spec.label, expectedDim);
   }
   for (let i = 0; i < out.length; i++) {
@@ -335,8 +343,8 @@ function makeTransformersEmbedder(
       } catch (err) {
         throw new Error(
           `Provider 'transformers' needs the optional package — run ` +
-          `\`npm i @huggingface/transformers\`, or switch [search] embedding_provider ` +
-          `to 'ollama'. (${(err as Error).message})`
+            `\`npm i @huggingface/transformers\`, or switch [search] embedding_provider ` +
+            `to 'ollama'. (${(err as Error).message})`
         );
       }
       const pipe = (await mod.pipeline("feature-extraction", model)) as (

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -6,7 +6,7 @@ import { EmbedCache, capEmbeddingText, embedText } from "./embed-cache.js";
 import { createEmbedder } from "./embeddings.js";
 import type { Embedder } from "./embeddings.js";
 import { tokenize } from "./tokenize.js";
-import type { SearchHit, SearchMode, SearchOptions } from "./types.js";
+import type { SearchHit, SearchOptions } from "./types.js";
 import { VectorIndex } from "./vector-store.js";
 
 export type { SearchHit, SearchMode, SearchOptions } from "./types.js";
@@ -198,7 +198,9 @@ export async function similarTasks(
     const bmCorpus = corpus.map((e) => e.task);
     const queryTokens = tokenize(`${target.title} ${target.tags.join(" ")}`);
     const bmHits =
-      queryTokens.length > 0 ? new BM25Index(bmCorpus).queryTokens(queryTokens, bmCorpus.length) : [];
+      queryTokens.length > 0
+        ? new BM25Index(bmCorpus).queryTokens(queryTokens, bmCorpus.length)
+        : [];
     return rrfFuse([bmHits, semHits], limit);
   }
 

--- a/src/search/vector-store.ts
+++ b/src/search/vector-store.ts
@@ -31,7 +31,7 @@ export class VectorIndex {
       if (v.length !== this.dim) {
         throw new Error(
           `Vector dimension mismatch at item ${i}: expected ${this.dim}, got ${v.length}. ` +
-          `The embedding cache may be from a different model — delete .vault-tasks/embeddings.json.`
+            `The embedding cache may be from a different model — delete .vault-tasks/embeddings.json.`
         );
       }
       this.vectors.push(normalize(v, i));

--- a/src/slugify.ts
+++ b/src/slugify.ts
@@ -2,7 +2,7 @@
  * Convert a title to a kebab-case slug, truncated at word boundaries.
  */
 export function slugify(title: string, maxLength = 60): string {
-  let slug = title
+  const slug = title
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9\s-]/g, "")

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,14 +16,7 @@ import { parseFrontmatter, writeFrontmatter } from "./frontmatter.js";
 import { slugify } from "./slugify.js";
 import type { CreateTaskOpts, Task } from "./task.js";
 
-const KNOWN_META_KEYS = new Set([
-  "title",
-  "status",
-  "priority",
-  "tags",
-  "created",
-  "source",
-]);
+const KNOWN_META_KEYS = new Set(["title", "status", "priority", "tags", "created", "source"]);
 
 // Strict ID prefix for a task filename. Matches:
 //   - Canonical ULID (26-char Crockford base32, no I/L/O/U)
@@ -132,9 +125,7 @@ export class TaskStore {
     const body = opts.body ?? `# ${title}\n\n`;
 
     if (!this.config.priorities.includes(priority)) {
-      throw new Error(
-        `Invalid priority: ${priority}. Use: ${this.config.priorities.join(", ")}`
-      );
+      throw new Error(`Invalid priority: ${priority}. Use: ${this.config.priorities.join(", ")}`);
     }
 
     const today = new Date().toISOString().slice(0, 10);
@@ -218,8 +209,8 @@ export class TaskStore {
       const names = matches.map((m) => basename(m));
       return new Error(
         `Ambiguous match for '${identifier}' — ${matches.length} candidates:\n` +
-        `${names.map((n) => `  ${n}`).join("\n")}\n` +
-        `Use more characters of the ID, or the full filename stem.`
+          `${names.map((n) => `  ${n}`).join("\n")}\n` +
+          `Use more characters of the ID, or the full filename stem.`
       );
     };
 
@@ -263,7 +254,7 @@ export class TaskStore {
       const upperIdent = identifier.toUpperCase();
       const prefixMatches = files.filter((f) => {
         const fileId = parseTaskIdFromFilename(basename(f));
-        return fileId !== null && fileId.toUpperCase().startsWith(upperIdent);
+        return fileId?.toUpperCase().startsWith(upperIdent);
       });
       if (prefixMatches.length === 1) {
         return fileToTask(prefixMatches[0], readFileSync(prefixMatches[0], "utf-8"));
@@ -396,9 +387,7 @@ export class TaskStore {
     for (const task of openTasks) {
       if (!task.created || !/^\d{4}-\d{2}-\d{2}/.test(task.created)) continue;
       const created = new Date(task.created);
-      const age = Math.floor(
-        (today.getTime() - created.getTime()) / (1000 * 60 * 60 * 24)
-      );
+      const age = Math.floor((today.getTime() - created.getTime()) / (1000 * 60 * 60 * 24));
       if (age < days) continue;
       candidates.push({ task, ageDays: age });
       if (!earliestDate || task.created < earliestDate) {
@@ -443,9 +432,7 @@ export class TaskStore {
 
   archiveCompleted(): Task[] {
     const tasks = this.loadAll();
-    const toArchive = tasks.filter((t) =>
-      this.config.archiveStatuses.includes(t.status)
-    );
+    const toArchive = tasks.filter((t) => this.config.archiveStatuses.includes(t.status));
 
     if (toArchive.length === 0) return [];
     this.ensureArchiveDir();
@@ -475,7 +462,9 @@ export class TaskStore {
     const name = basename(task.filePath);
     const dest = join(this.config.archiveDir, name);
     if (existsSync(dest)) {
-      throw new Error(`Archive destination already exists: ${name}. Resolve the conflict manually.`);
+      throw new Error(
+        `Archive destination already exists: ${name}. Resolve the conflict manually.`
+      );
     }
     renameSync(task.filePath, dest);
     task.filePath = dest;

--- a/src/tests/bm25.test.ts
+++ b/src/tests/bm25.test.ts
@@ -87,16 +87,22 @@ describe("BM25Index", () => {
     const rareHits = idx.query("rare", 5);
     const commonHits = idx.query("common", 5);
     assert.equal(rareHits.length, 1);
-    assert.ok(rareHits[0].score > commonHits[0].score,
-      `rare-term score (${rareHits[0].score}) should exceed common-term top (${commonHits[0].score})`);
+    assert.ok(
+      rareHits[0].score > commonHits[0].score,
+      `rare-term score (${rareHits[0].score}) should exceed common-term top (${commonHits[0].score})`
+    );
   });
 
   it("saturates term frequency (k1 bound)", () => {
     // BM25's TF saturation: adding a 4th occurrence yields less score than
     // adding the 2nd occurrence. We verify by comparing single-term scores on
     // documents that differ only in how often the query term appears.
-    const lowReps = task({ id: "0001", title: "auth", body: "auth" });          // 2 occurrences (title doubled)
-    const highReps = task({ id: "0002", title: "auth", body: "auth auth auth auth auth auth auth auth" });
+    const lowReps = task({ id: "0001", title: "auth", body: "auth" }); // 2 occurrences (title doubled)
+    const highReps = task({
+      id: "0002",
+      title: "auth",
+      body: "auth auth auth auth auth auth auth auth",
+    });
     const idx = new BM25Index([lowReps, highReps]);
     const hits = idx.query("auth", 5);
     const lowScore = hits.find((h) => h.task.id === "0001")!.score;
@@ -104,8 +110,10 @@ describe("BM25Index", () => {
     // High-reps must score higher (more matches) ...
     assert.ok(highScore > lowScore);
     // ... but not 4x higher (TF saturation), even though it has ~5x more occurrences.
-    assert.ok(highScore < lowScore * 4,
-      `TF should saturate: highScore=${highScore} not ~5x lowScore=${lowScore}`);
+    assert.ok(
+      highScore < lowScore * 4,
+      `TF should saturate: highScore=${highScore} not ~5x lowScore=${lowScore}`
+    );
   });
 
   it("respects the limit parameter", () => {
@@ -138,10 +146,7 @@ describe("BM25Index", () => {
   });
 
   it("size reflects the document count", () => {
-    const idx = new BM25Index([
-      task({ id: "0001", title: "a" }),
-      task({ id: "0002", title: "b" }),
-    ]);
+    const idx = new BM25Index([task({ id: "0001", title: "a" }), task({ id: "0002", title: "b" })]);
     assert.equal(idx.size, 2);
   });
 });

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { parseFrontmatter } from "../frontmatter.js";
@@ -53,11 +60,7 @@ function runWithStdin(args: string[], cwd: string, input: string): RunResult {
   }
 }
 
-function runWithEnv(
-  args: string[],
-  cwd: string,
-  env: Record<string, string>
-): RunResult {
+function runWithEnv(args: string[], cwd: string, env: Record<string, string>): RunResult {
   try {
     const stdout = execFileSync("node", [CLI, ...args], {
       cwd,
@@ -107,7 +110,10 @@ describe("CLI integration", () => {
   });
 
   it("new creates task file with correct frontmatter", () => {
-    const result = run(["new", "Test task", "--priority", "high", "--tags", "ui,auth", "--source", "[[2026-03-31]]"], dir);
+    const result = run(
+      ["new", "Test task", "--priority", "high", "--tags", "ui,auth", "--source", "[[2026-03-31]]"],
+      dir
+    );
     assert.equal(result.exitCode, 0);
 
     const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md"));
@@ -153,7 +159,10 @@ describe("CLI integration", () => {
     const result = run(["search", "auth", "--mode", "bm25"], dir);
     assert.equal(result.exitCode, 0);
     // Header should include SCORE column for bm25 output.
-    assert.ok(result.stdout.includes("SCORE"), `expected SCORE column in output:\n${result.stdout}`);
+    assert.ok(
+      result.stdout.includes("SCORE"),
+      `expected SCORE column in output:\n${result.stdout}`
+    );
     // Both auth-containing tasks should appear; the DB migration should not.
     assert.ok(result.stdout.includes("Fix auth redirect bug"));
     assert.ok(result.stdout.includes("Auth callback handling"));
@@ -174,8 +183,10 @@ describe("CLI integration", () => {
     const result = run(["search", "--like", "1", "--mode", "bm25"], dir);
     assert.equal(result.exitCode, 0);
     // The target task itself must NOT appear in the output.
-    assert.ok(!result.stdout.includes("Fix auth redirect bug"),
-      `target task should be excluded:\n${result.stdout}`);
+    assert.ok(
+      !result.stdout.includes("Fix auth redirect bug"),
+      `target task should be excluded:\n${result.stdout}`
+    );
     // A related task should appear; an unrelated one should not.
     assert.ok(result.stdout.includes("Fix auth callback handling"));
     assert.ok(!result.stdout.includes("Refactor database migration"));
@@ -229,9 +240,7 @@ describe("CLI integration", () => {
     }
     const result = run(["search", "auth", "--mode", "bm25", "--limit", "2"], dir);
     assert.equal(result.exitCode, 0);
-    const taskRows = result.stdout
-      .split("\n")
-      .filter((l) => /^\d{4}\s/.test(l));
+    const taskRows = result.stdout.split("\n").filter((l) => /^\d{4}\s/.test(l));
     assert.equal(taskRows.length, 2);
   });
 
@@ -258,7 +267,10 @@ describe("CLI integration", () => {
 
   it("search --limit rejects unsafe-integer values", () => {
     run(["new", "Fix auth bug"], dir);
-    const result = run(["search", "auth", "--mode", "bm25", "--limit", "99999999999999999999"], dir);
+    const result = run(
+      ["search", "auth", "--mode", "bm25", "--limit", "99999999999999999999"],
+      dir
+    );
     assert.equal(result.exitCode, 1);
     assert.match(result.stderr, /--limit must be a positive integer/);
   });
@@ -276,8 +288,10 @@ describe("CLI integration", () => {
     run(["new", "high auth task", "--priority", "high"], dir);
     const result = run(["search", "auth", "--limit", "1"], dir);
     assert.equal(result.exitCode, 0);
-    assert.ok(result.stdout.includes("high auth task"),
-      `--limit 1 must keep the highest-priority match:\n${result.stdout}`);
+    assert.ok(
+      result.stdout.includes("high auth task"),
+      `--limit 1 must keep the highest-priority match:\n${result.stdout}`
+    );
   });
 
   it("search keyword mode matches task tags", () => {
@@ -595,8 +609,8 @@ describe("CLI with ULID strategy", () => {
     // The default is "commented-out" but the example string must be "ulid".
     assert.match(
       config,
-      /\[id\][^\[]*strategy\s*=\s*"ulid"/s,
-      "default config should document strategy = \"ulid\" under [id]"
+      /\[id\][^[]*strategy\s*=\s*"ulid"/s,
+      'default config should document strategy = "ulid" under [id]'
     );
   });
 
@@ -635,7 +649,9 @@ describe("CLI with ULID strategy", () => {
     assert.ok(result.stdout.includes("archived"));
 
     // Task should be in archive
-    const archiveFiles = readdirSync(join(dir, "backlog", "archive")).filter((f: string) => f.endsWith(".md"));
+    const archiveFiles = readdirSync(join(dir, "backlog", "archive")).filter((f: string) =>
+      f.endsWith(".md")
+    );
     assert.equal(archiveFiles.length, 1);
   });
 
@@ -669,8 +685,10 @@ describe("CLI with ULID strategy", () => {
     run(["new", "Duplicate me"], dir);
     const result = run(["new", "Duplicate me", "--no-dedupe=true"], dir);
     assert.equal(result.exitCode, 0);
-    assert.ok(!result.stderr.includes("Similar tasks found"),
-      "--no-dedupe=true must suppress the warning");
+    assert.ok(
+      !result.stderr.includes("Similar tasks found"),
+      "--no-dedupe=true must suppress the warning"
+    );
   });
 
   it("--no-dedupe=garbage is rejected with actionable error", () => {
@@ -722,7 +740,9 @@ describe("CLI legacy sequential detection", () => {
     const result = run(["new", "Second task"], dir);
     assert.equal(result.exitCode, 0, `stderr: ${result.stderr}`);
 
-    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md")).sort();
+    const files = readdirSync(join(dir, "backlog"))
+      .filter((f: string) => f.endsWith(".md"))
+      .sort();
     assert.equal(files.length, 2);
     // Second file must be NNNN-prefixed, not a 26-char ULID
     assert.match(files[1], /^0002-/);
@@ -755,7 +775,9 @@ describe("CLI legacy sequential detection", () => {
     const result = run(["new", "Next task"], dir);
     assert.equal(result.exitCode, 0, `stderr: ${result.stderr}`);
 
-    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md")).sort();
+    const files = readdirSync(join(dir, "backlog"))
+      .filter((f: string) => f.endsWith(".md"))
+      .sort();
     assert.equal(files.length, 2);
     assert.match(files[1], /^0043-/);
   });
@@ -776,7 +798,9 @@ describe("CLI legacy sequential detection", () => {
 
     const result = run(["new", "New ulid"], dir);
     assert.equal(result.exitCode, 0);
-    const files = readdirSync(join(dir, "backlog")).filter((f: string) => f.endsWith(".md")).sort();
+    const files = readdirSync(join(dir, "backlog"))
+      .filter((f: string) => f.endsWith(".md"))
+      .sort();
     assert.equal(files.length, 2);
     // New file must be a ULID, not 0002
     assert.ok(
@@ -794,10 +818,7 @@ describe("CLI config validation", () => {
   });
 
   it("rejects invalid [id] strategy with actionable error", () => {
-    writeFileSync(
-      join(dir, ".vault-tasks.toml"),
-      '[id]\nstrategy = "uild"\n'
-    );
+    writeFileSync(join(dir, ".vault-tasks.toml"), '[id]\nstrategy = "uild"\n');
     const result = run(["list"], dir);
     assert.notEqual(result.exitCode, 0);
     assert.match(result.stderr, /Invalid \[id\] strategy/);
@@ -805,10 +826,7 @@ describe("CLI config validation", () => {
   });
 
   it("rejects dedupe_threshold out of range", () => {
-    writeFileSync(
-      join(dir, ".vault-tasks.toml"),
-      '[task]\ndedupe_threshold = 2\n'
-    );
+    writeFileSync(join(dir, ".vault-tasks.toml"), "[task]\ndedupe_threshold = 2\n");
     const result = run(["list"], dir);
     assert.notEqual(result.exitCode, 0);
     assert.match(result.stderr, /dedupe_threshold/);
@@ -839,11 +857,7 @@ describe("CLI config validation", () => {
   });
 
   it("new --body - reads body from stdin", () => {
-    const result = runWithStdin(
-      ["new", "Stdin task", "--body", "-"],
-      dir,
-      "Piped body content"
-    );
+    const result = runWithStdin(["new", "Stdin task", "--body", "-"], dir, "Piped body content");
     assert.equal(result.exitCode, 0);
 
     const files = readdirSync(join(dir, "backlog")).filter((f) => f.endsWith(".md"));
@@ -854,10 +868,7 @@ describe("CLI config validation", () => {
   });
 
   it("new --body and --body-file are mutually exclusive", () => {
-    const result = run(
-      ["new", "T", "--body", "x", "--body-file", "y"],
-      dir
-    );
+    const result = run(["new", "T", "--body", "x", "--body-file", "y"], dir);
     assert.equal(result.exitCode, 2);
     assert.match(result.stderr, /mutually exclusive/);
   });
@@ -979,11 +990,9 @@ describe("CLI config validation", () => {
     // command must run inside the CLI's main try/catch so users get a clean
     // one-line error and a non-zero exit code, not an unhandled exception.
     const missing = join(dir, "does-not-exist-templates-dir");
-    const result = runWithEnv(
-      ["install-skills", "--list"],
-      dir,
-      { VAULT_TASKS_TEMPLATES_DIR: missing }
-    );
+    const result = runWithEnv(["install-skills", "--list"], dir, {
+      VAULT_TASKS_TEMPLATES_DIR: missing,
+    });
     assert.equal(result.exitCode, 1);
     assert.match(result.stderr, /VAULT_TASKS_TEMPLATES_DIR/);
     assert.ok(result.stderr.includes(missing), "error must include the offending path");

--- a/src/tests/config.test.ts
+++ b/src/tests/config.test.ts
@@ -39,7 +39,7 @@ archive_dir = "archive"`);
   });
 
   it("skips comments", () => {
-    const result = parseToml("# comment\nname = \"test\"");
+    const result = parseToml('# comment\nname = "test"');
     assert.equal(result["name"], "test");
   });
 
@@ -80,7 +80,7 @@ archive_dir = "archive"`);
   });
 
   it("handles CRLF line endings", () => {
-    const result = parseToml("[paths]\r\nbacklog_dir = \"backlog\"\r\narchive_dir = \"archive\"");
+    const result = parseToml('[paths]\r\nbacklog_dir = "backlog"\r\narchive_dir = "archive"');
     const paths = result["paths"] as Record<string, unknown>;
     assert.equal(paths["backlog_dir"], "backlog");
     assert.equal(paths["archive_dir"], "archive");
@@ -107,7 +107,7 @@ archive_dir = "archive"`);
     // The regex requires .+ after =, so this line is simply skipped
     const result = parseToml("[task]\nname = ");
     // name = " " matches the regex with rawValue = "", which becomes empty string
-    const task = result["task"] as Record<string, unknown>;
+    const _task = result["task"] as Record<string, unknown>;
     // The behavior depends on the regex — if it doesn't match, the key is skipped
     assert.ok(true); // Just verify no crash
   });
@@ -154,7 +154,10 @@ describe("loadConfig", () => {
 
   it("resolves paths from config file location", () => {
     const dir = mkdtempSync(join(tmpdir(), "vt-cfg-"));
-    writeFileSync(join(dir, ".vault-tasks.toml"), '[paths]\nbacklog_dir = "tasks"\narchive_dir = "done"');
+    writeFileSync(
+      join(dir, ".vault-tasks.toml"),
+      '[paths]\nbacklog_dir = "tasks"\narchive_dir = "done"'
+    );
     const config = loadConfig(dir);
     assert.equal(config.vaultRoot, dir);
     assert.equal(config.backlogDir, join(dir, "tasks"));
@@ -163,7 +166,10 @@ describe("loadConfig", () => {
 
   it("resolves custom vault structure paths from config", () => {
     const dir = mkdtempSync(join(tmpdir(), "vt-cfg-"));
-    writeFileSync(join(dir, ".vault-tasks.toml"), '[paths]\njournal_dir = "journal"\nprojects_dir = "projects"\nevergreen_dir = "notes"');
+    writeFileSync(
+      join(dir, ".vault-tasks.toml"),
+      '[paths]\njournal_dir = "journal"\nprojects_dir = "projects"\nevergreen_dir = "notes"'
+    );
     const config = loadConfig(dir);
     assert.equal(config.journalDir, join(dir, "journal"));
     assert.equal(config.projectsDir, join(dir, "projects"));

--- a/src/tests/embed-cache.test.ts
+++ b/src/tests/embed-cache.test.ts
@@ -96,10 +96,16 @@ describe("EmbedCache", () => {
 
   it("invalidates the whole cache when the model changes", async () => {
     const first = trackingEmbedder("model-a");
-    await new EmbedCache(dir, "ollama", "model-a").getOrCompute([task("1", "alpha")], first.embedder);
+    await new EmbedCache(dir, "ollama", "model-a").getOrCompute(
+      [task("1", "alpha")],
+      first.embedder
+    );
 
     const second = trackingEmbedder("model-b");
-    await new EmbedCache(dir, "ollama", "model-b").getOrCompute([task("1", "alpha")], second.embedder);
+    await new EmbedCache(dir, "ollama", "model-b").getOrCompute(
+      [task("1", "alpha")],
+      second.embedder
+    );
     assert.equal(second.calls.length, 1, "a different model must not reuse cached vectors");
   });
 

--- a/src/tests/embeddings.test.ts
+++ b/src/tests/embeddings.test.ts
@@ -63,7 +63,10 @@ describe("createEmbedder", () => {
     const emb = createEmbedder(cfg({ embeddingProvider: "ollama" }));
     const out = await emb.embed(["hello"]);
     assert.deepEqual(out, [[0.1, 0.2, 0.3]]);
-    assert.ok(calls[0].url.startsWith("http://localhost:11434"), "uses the ollama default endpoint");
+    assert.ok(
+      calls[0].url.startsWith("http://localhost:11434"),
+      "uses the ollama default endpoint"
+    );
   });
 
   it("openai-shape: posts to /v1/embeddings and parses { data[].embedding }", async () => {
@@ -85,9 +88,14 @@ describe("createEmbedder", () => {
         ],
       },
     }));
-    const emb = createEmbedder(cfg({ embeddingProvider: "openai-compatible", embeddingEndpoint: "http://x" }));
+    const emb = createEmbedder(
+      cfg({ embeddingProvider: "openai-compatible", embeddingEndpoint: "http://x" })
+    );
     const out = await emb.embed(["a", "b"]);
-    assert.deepEqual(out, [[1, 1], [9, 9]]);
+    assert.deepEqual(out, [
+      [1, 1],
+      [9, 9],
+    ]);
   });
 
   it("chunks large inputs into batches", async () => {
@@ -168,10 +176,7 @@ describe("createEmbedder", () => {
   });
 
   it("cloud provider without an api key env name throws at construction", () => {
-    assert.throws(
-      () => createEmbedder(cfg({ embeddingProvider: "openai" })),
-      /needs an API key/
-    );
+    assert.throws(() => createEmbedder(cfg({ embeddingProvider: "openai" })), /needs an API key/);
   });
 
   it("cloud provider with an unset api key env var throws at construction", () => {
@@ -204,7 +209,9 @@ describe("createEmbedder", () => {
   it("transformers: constructs without throwing and defers the model load", () => {
     // The pipeline (and the optional dependency import) load lazily on first
     // embed(), so construction must not require the package to be present.
-    const emb = createEmbedder(cfg({ embeddingProvider: "transformers", embeddingModel: "some/model" }));
+    const emb = createEmbedder(
+      cfg({ embeddingProvider: "transformers", embeddingModel: "some/model" })
+    );
     assert.equal(emb.provider, "transformers");
     assert.equal(emb.model, "some/model");
   });

--- a/src/tests/frontmatter.test.ts
+++ b/src/tests/frontmatter.test.ts
@@ -69,13 +69,13 @@ More text`;
   });
 
   it("handles value containing colon", () => {
-    const text = "---\ntitle: \"Fix: the login bug\"\n---\nBody";
+    const text = '---\ntitle: "Fix: the login bug"\n---\nBody';
     const { meta } = parseFrontmatter(text);
     assert.equal(meta["title"], "Fix: the login bug");
   });
 
   it("handles value containing --- in frontmatter", () => {
-    const text = "---\ntitle: \"Phase 1 --- Phase 2\"\n---\nBody";
+    const text = '---\ntitle: "Phase 1 --- Phase 2"\n---\nBody';
     const { meta } = parseFrontmatter(text);
     assert.equal(meta["title"], "Phase 1 --- Phase 2");
   });
@@ -349,9 +349,7 @@ tags:
     // ULIDs are all-uppercase Crockford base32; they must round-trip as a
     // plain string, not be coerced to a number or YAML-quoted unnecessarily.
     const ulid = "01HYXABCDEFGHJKMNPQRSTVWXY";
-    const { meta: parsed } = parseFrontmatter(
-      writeFrontmatter({ id: ulid, title: "t" }, "body")
-    );
+    const { meta: parsed } = parseFrontmatter(writeFrontmatter({ id: ulid, title: "t" }, "body"));
     assert.equal(parsed["id"], ulid);
     assert.equal(typeof parsed["id"], "string");
   });
@@ -386,9 +384,7 @@ Body`;
   it("round-trips a purely-numeric id string without becoming a number", () => {
     // A numeric task ID like "42" must survive write/parse as a string so
     // callers comparing `task.id === "42"` still succeed.
-    const { meta: parsed } = parseFrontmatter(
-      writeFrontmatter({ id: "42", title: "t" }, "body")
-    );
+    const { meta: parsed } = parseFrontmatter(writeFrontmatter({ id: "42", title: "t" }, "body"));
     assert.equal(parsed["id"], "42");
     assert.equal(typeof parsed["id"], "string");
   });

--- a/src/tests/install-skills.test.ts
+++ b/src/tests/install-skills.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import {
-  mkdtempSync,
-  mkdirSync,
-  writeFileSync,
-  readFileSync,
-  existsSync,
-} from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Config } from "../config.js";
@@ -92,14 +86,8 @@ describe("install-skills VAULT_TASKS_TEMPLATES_DIR override", () => {
       "# demo skill from override path\n"
     );
     mkdirSync(join(templatesDir, "rules"), { recursive: true });
-    writeFileSync(
-      join(templatesDir, "rules", "demo.md"),
-      "# demo rule from override path\n"
-    );
-    writeFileSync(
-      join(templatesDir, "backlog.base"),
-      "filters:\n  folder: '{{backlog_dir}}'\n"
-    );
+    writeFileSync(join(templatesDir, "rules", "demo.md"), "# demo rule from override path\n");
+    writeFileSync(join(templatesDir, "backlog.base"), "filters:\n  folder: '{{backlog_dir}}'\n");
   });
 
   afterEach(() => {
@@ -122,18 +110,9 @@ describe("install-skills VAULT_TASKS_TEMPLATES_DIR override", () => {
     captureLogs(() => {
       cmdInstallSkills(makeConfig(vaultRoot), { install: true });
     });
-    const installedSkill = join(
-      vaultRoot,
-      ".claude",
-      "skills",
-      "demo",
-      "SKILL.md"
-    );
+    const installedSkill = join(vaultRoot, ".claude", "skills", "demo", "SKILL.md");
     assert.ok(existsSync(installedSkill), "skill should be installed in vault");
-    assert.equal(
-      readFileSync(installedSkill, "utf-8"),
-      "# demo skill from override path\n"
-    );
+    assert.equal(readFileSync(installedSkill, "utf-8"), "# demo skill from override path\n");
     const installedBase = join(vaultRoot, "backlog", "backlog.base");
     assert.ok(existsSync(installedBase), "base file should be installed");
     assert.match(readFileSync(installedBase, "utf-8"), /folder: 'backlog'/);
@@ -148,10 +127,7 @@ describe("install-skills VAULT_TASKS_TEMPLATES_DIR override", () => {
       },
       (err: Error) => {
         assert.match(err.message, /VAULT_TASKS_TEMPLATES_DIR/);
-        assert.ok(
-          err.message.includes(missing),
-          "error must include the offending path"
-        );
+        assert.ok(err.message.includes(missing), "error must include the offending path");
         assert.match(err.message, /does not exist/);
         assert.match(err.message, /Unset it or point it/);
         return true;
@@ -169,10 +145,7 @@ describe("install-skills VAULT_TASKS_TEMPLATES_DIR override", () => {
       },
       (err: Error) => {
         assert.match(err.message, /VAULT_TASKS_TEMPLATES_DIR/);
-        assert.ok(
-          err.message.includes(filePath),
-          "error must include the offending path"
-        );
+        assert.ok(err.message.includes(filePath), "error must include the offending path");
         assert.match(err.message, /not a directory/);
         return true;
       }

--- a/src/tests/lint.test.ts
+++ b/src/tests/lint.test.ts
@@ -9,11 +9,7 @@ import { buildIndex, normKey, resolveTarget, stripTargetSuffixes } from "../lint
 import { collectWikilinks, isTemplatePlaceholder, readVaultFiles } from "../lint/collect.js";
 import { findBrokenLinks } from "../lint/checks/broken.js";
 import { attachSuggestions, computeLeverageFixes } from "../lint/suggest.js";
-import {
-  formatHumanReport,
-  formatJsonReport,
-  formatSummaryLine,
-} from "../lint/report.js";
+import { formatHumanReport, formatJsonReport, formatSummaryLine } from "../lint/report.js";
 import type { BrokenEntry, LintReport } from "../lint/types.js";
 
 function makeConfig(dir: string, overrides: Partial<Config["lint"]> = {}): Config {
@@ -115,11 +111,7 @@ describe("buildIndex + resolveTarget", () => {
   });
 
   it("resolves against title: frontmatter", () => {
-    write(
-      dir,
-      "title-fm.md",
-      "---\ntitle: \"Some Title\"\n---\nBody"
-    );
+    write(dir, "title-fm.md", '---\ntitle: "Some Title"\n---\nBody');
     const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
     const idx = buildIndex(files);
     assert.equal(resolveTarget("Some Title", idx), "title-fm.md");
@@ -127,11 +119,7 @@ describe("buildIndex + resolveTarget", () => {
   });
 
   it("resolves against aliases", () => {
-    write(
-      dir,
-      "canonical.md",
-      "---\ntitle: Canonical\naliases: [bioform-ai, BioForm]\n---\nBody"
-    );
+    write(dir, "canonical.md", "---\ntitle: Canonical\naliases: [bioform-ai, BioForm]\n---\nBody");
     const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
     const idx = buildIndex(files);
     assert.equal(resolveTarget("bioform ai", idx), "canonical.md");
@@ -151,10 +139,7 @@ describe("buildIndex + resolveTarget", () => {
     write(dir, "10-areas/investing/CONTEXT.md", "Body");
     const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
     const idx = buildIndex(files);
-    assert.equal(
-      resolveTarget("parenting/CONTEXT", idx),
-      "10-areas/parenting/CONTEXT.md"
-    );
+    assert.equal(resolveTarget("parenting/CONTEXT", idx), "10-areas/parenting/CONTEXT.md");
     // Just "CONTEXT" is ambiguous (two files share the basename) — must
     // not silently pick one.
     assert.equal(resolveTarget("CONTEXT", idx), null);
@@ -285,7 +270,7 @@ describe("attachSuggestions", () => {
     write(dir, "bioform-ai.md", "---\ntitle: BioForm AI\n---\nBody");
     write(dir, "broken.md", "[[bioform ai]]");
     const files = readVaultFiles(dir, [".git", "node_modules"], () => {});
-    const links = collectWikilinks(files, [], [], []);
+    const _links = collectWikilinks(files, [], [], []);
     const idx = buildIndex(files);
     // Nothing's broken because resolution succeeds via title match.
     // Test the suggestion engine directly with a forced broken entry.
@@ -322,9 +307,7 @@ describe("attachSuggestions", () => {
 
   it("computes leverage fixes summed across broken targets", () => {
     write(dir, "canonical.md", "---\ntitle: Canonical\n---\nBody");
-    const idx = buildIndex(
-      readVaultFiles(dir, [".git", "node_modules"], () => {})
-    );
+    const idx = buildIndex(readVaultFiles(dir, [".git", "node_modules"], () => {}));
     const broken: BrokenEntry[] = [
       {
         target: "canonicaal", // typo, similar to "canonical"
@@ -360,7 +343,11 @@ describe("lintVault", () => {
       "30-evergreen/note.md",
       "---\ntitle: Note\ntags: [foo]\n---\n# Note\n\n[[other]]\n\n## Related\n\n[[other]]"
     );
-    write(dir, "30-evergreen/other.md", "---\ntitle: Other\ntags: [foo]\n---\n# Other\n\n[[note]]\n\n## Related\n\n[[note]]");
+    write(
+      dir,
+      "30-evergreen/other.md",
+      "---\ntitle: Other\ntags: [foo]\n---\n# Other\n\n[[note]]\n\n## Related\n\n[[note]]"
+    );
     const cfg = makeConfig(dir);
     const report = lintVault(cfg);
     assert.equal(report.summary.broken, 0);
@@ -383,7 +370,11 @@ describe("lintVault", () => {
     // Stale: a reference with no incoming links
     write(dir, "40-references/abandoned.md", "Body");
     // Resolution target for [[somewhere]]
-    write(dir, "30-evergreen/somewhere.md", "---\ntitle: Somewhere\ntags: [x]\n---\n# Somewhere\n\n[[lonely]]\n\n## Related");
+    write(
+      dir,
+      "30-evergreen/somewhere.md",
+      "---\ntitle: Somewhere\ntags: [x]\n---\n# Somewhere\n\n[[lonely]]\n\n## Related"
+    );
 
     const cfg = makeConfig(dir);
     const report = lintVault(cfg);
@@ -400,10 +391,11 @@ describe("lintVault", () => {
     assert.deepEqual(report.orphans, ["30-evergreen/messy.md"]);
     assert.deepEqual(report.stale, ["40-references/abandoned.md"]);
     assert.equal(report.drift[0].filePath, "30-evergreen/messy.md");
-    assert.deepEqual(
-      report.drift[0].issues,
-      ["no frontmatter", "no wikilinks in body", "no ## Related section"]
-    );
+    assert.deepEqual(report.drift[0].issues, [
+      "no frontmatter",
+      "no wikilinks in body",
+      "no ## Related section",
+    ]);
     assert.equal(report.hasIssues, true);
   });
 
@@ -427,7 +419,11 @@ describe("lintVault", () => {
       "30-evergreen/inbox.md",
       "---\ntitle: Inbox\ntags: [x]\nlint_orphan_ok: true\n---\n# Inbox\n\n[[noop]]\n\n## Related"
     );
-    write(dir, "30-evergreen/noop.md", "---\ntitle: Noop\ntags: [x]\n---\n# Noop\n\n[[inbox]]\n\n## Related");
+    write(
+      dir,
+      "30-evergreen/noop.md",
+      "---\ntitle: Noop\ntags: [x]\n---\n# Noop\n\n[[inbox]]\n\n## Related"
+    );
     const cfg = makeConfig(dir);
     const report = lintVault(cfg, { only: "orphans" });
     assert.equal(report.summary.orphans, 0);
@@ -448,7 +444,11 @@ describe("lintVault", () => {
     // [[shared]] lives outside the scope; it should still resolve so the
     // link inside the scope is not falsely flagged as broken.
     write(dir, "shared.md", "---\ntitle: Shared\n---\nBody");
-    write(dir, "30-evergreen/note.md", "---\ntitle: Note\ntags: [x]\n---\n# Note\n\n[[shared]]\n\n## Related");
+    write(
+      dir,
+      "30-evergreen/note.md",
+      "---\ntitle: Note\ntags: [x]\n---\n# Note\n\n[[shared]]\n\n## Related"
+    );
     const cfg = makeConfig(dir);
     const report = lintVault(cfg, { scope: "30-evergreen" });
     assert.equal(report.summary.broken, 0);
@@ -628,15 +628,8 @@ describe("config validation for [lint]", () => {
 
   it("rejects an invalid template_patterns regex with file context", async () => {
     const { loadConfig } = await import("../config.js");
-    write(
-      dir,
-      ".vault-tasks.toml",
-      `[lint]\ntemplate_patterns = ["valid", "[unclosed"]\n`
-    );
-    assert.throws(
-      () => loadConfig(dir),
-      /template_patterns\[1\]:.*"\[unclosed"/
-    );
+    write(dir, ".vault-tasks.toml", `[lint]\ntemplate_patterns = ["valid", "[unclosed"]\n`);
+    assert.throws(() => loadConfig(dir), /template_patterns\[1\]:.*"\[unclosed"/);
   });
 
   it("rejects suggestion_threshold outside 0..1", async () => {

--- a/src/tests/output.test.ts
+++ b/src/tests/output.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { sortByPriority, formatTaskTable, formatStaleTable, formatTagList, formatSearchHits, sanitizeForDisplay } from "../output.js";
+import {
+  sortByPriority,
+  formatTaskTable,
+  formatStaleTable,
+  formatTagList,
+  formatSearchHits,
+  sanitizeForDisplay,
+} from "../output.js";
 import type { Task } from "../task.js";
 import type { SearchHit } from "../search/types.js";
 
@@ -55,10 +62,7 @@ describe("sortByPriority", () => {
   });
 
   it("does not mutate original array", () => {
-    const tasks = [
-      makeTask({ priority: "low" }),
-      makeTask({ priority: "high" }),
-    ];
+    const tasks = [makeTask({ priority: "low" }), makeTask({ priority: "high" })];
     const original = [...tasks];
     sortByPriority(tasks);
     assert.equal(tasks[0].priority, original[0].priority);
@@ -107,7 +111,10 @@ describe("formatTagList", () => {
   });
 
   it("sorts tags alphabetically", () => {
-    const tags = new Map([["zebra", 1], ["alpha", 2]]);
+    const tags = new Map([
+      ["zebra", 1],
+      ["alpha", 2],
+    ]);
     const result = formatTagList(tags);
     const lines = result.split("\n");
     assert.ok(lines[0].includes("alpha"));
@@ -164,7 +171,10 @@ describe("formatSearchHits", () => {
       mode: "bm25",
     };
     const result = formatSearchHits([hit]);
-    assert.ok(!result.includes("\x1b"), `escape sequence must be stripped: ${JSON.stringify(result)}`);
+    assert.ok(
+      !result.includes("\x1b"),
+      `escape sequence must be stripped: ${JSON.stringify(result)}`
+    );
     assert.ok(result.includes("Injected"));
   });
 
@@ -176,7 +186,10 @@ describe("formatSearchHits", () => {
     };
     const result = formatSearchHits([hit]);
     // The output is header + divider + one row — no forged row.
-    const taskRows = result.split("\n").filter((l) => /^\S/.test(l)).slice(2);
+    const taskRows = result
+      .split("\n")
+      .filter((l) => /^\S/.test(l))
+      .slice(2);
     assert.equal(taskRows.length, 1);
     assert.ok(!result.includes("\n0099"));
   });
@@ -190,7 +203,10 @@ describe("formatSearchHits", () => {
       mode: "bm25",
     };
     const result = formatSearchHits([hit]);
-    const taskRows = result.split("\n").filter((l) => /^\S/.test(l)).slice(2);
+    const taskRows = result
+      .split("\n")
+      .filter((l) => /^\S/.test(l))
+      .slice(2);
     assert.equal(taskRows.length, 1, `forged row leaked via status column:\n${result}`);
     assert.ok(!result.includes("\n0099"));
   });

--- a/src/tests/search.test.ts
+++ b/src/tests/search.test.ts
@@ -103,8 +103,10 @@ describe("searchTasks", () => {
       assert.equal(h.mode, "bm25");
       assert.ok(h.score > 0);
     }
-    assert.ok(!hits.find((h) => h.task.title.includes("database")),
-      "unrelated task should not appear in BM25 results for 'auth'");
+    assert.ok(
+      !hits.find((h) => h.task.title.includes("database")),
+      "unrelated task should not appear in BM25 results for 'auth'"
+    );
   });
 
   it("keyword mode falls back to substring matching with score 1.0", async () => {
@@ -203,8 +205,10 @@ describe("similarTasks", () => {
     const target = store.create({ title: "Fix auth bug" });
     store.create({ title: "Fix auth callback handling" });
     const hits = await similarTasks(store, target, { mode: "bm25" });
-    assert.ok(!hits.find((h) => h.task.filePath === target.filePath),
-      "target task must be excluded from its own similarity results");
+    assert.ok(
+      !hits.find((h) => h.task.filePath === target.filePath),
+      "target task must be excluded from its own similarity results"
+    );
   });
 
   it("returns related tasks ranked by similarity", async () => {
@@ -280,7 +284,9 @@ describe("searchTasks semantic / hybrid", () => {
     // A task matching both lexically and semantically should outrank the
     // unrelated DB task.
     const dbIdx = hits.findIndex((h) => h.task.title.includes("database"));
-    const authIdx = hits.findIndex((h) => h.task.title.includes("auth") || h.task.title.includes("Auth"));
+    const authIdx = hits.findIndex(
+      (h) => h.task.title.includes("auth") || h.task.title.includes("Auth")
+    );
     assert.ok(authIdx >= 0);
     if (dbIdx >= 0) assert.ok(authIdx < dbIdx, "auth task should rank above the unrelated DB task");
   });

--- a/src/tests/similarity.test.ts
+++ b/src/tests/similarity.test.ts
@@ -22,10 +22,7 @@ describe("similarity", () => {
   });
 
   it("scores high for similar titles with minor differences", () => {
-    const score = similarity(
-      "Fix login redirect bug",
-      "Fix the login redirect issue"
-    );
+    const score = similarity("Fix login redirect bug", "Fix the login redirect issue");
     assert.ok(score > 0.5, `Expected > 0.5 for similar titles but got ${score}`);
   });
 
@@ -51,10 +48,7 @@ describe("similarity", () => {
   });
 
   it("distinguishes clearly different tasks", () => {
-    const score = similarity(
-      "Add user authentication",
-      "Fix database migration"
-    );
+    const score = similarity("Add user authentication", "Fix database migration");
     assert.ok(score < 0.3, `Expected < 0.3 for different tasks but got ${score}`);
   });
 

--- a/src/tests/store.test.ts
+++ b/src/tests/store.test.ts
@@ -173,10 +173,7 @@ describe("TaskStore", () => {
     // `created`, `source` must come before any extra key after an update.
     const task = store.create({ title: "Order check" });
     const content = readFileSync(task.filePath, "utf-8");
-    const modified = content.replace(
-      "\n---\n",
-      "\noncall_fix_kind: real-bug\n---\n"
-    );
+    const modified = content.replace("\n---\n", "\noncall_fix_kind: real-bug\n---\n");
     writeFileSync(task.filePath, modified);
 
     store.update("1", { priority: "high" });
@@ -215,7 +212,7 @@ describe("TaskStore", () => {
 
   it("findIncludingArchive returns archived tasks without throwing", () => {
     store.create({ title: "Active task" });
-    const archived = store.create({ title: "To archive" });
+    const _archived = store.create({ title: "To archive" });
     store.setStatus("2", "done");
     const t = store.findIncludingArchive("2");
     assert.equal(t.title, "To archive");
@@ -378,10 +375,7 @@ describe("TaskStore", () => {
     const recent = store.loadRecent(3);
     assert.equal(recent.length, 3);
     // Sequential IDs: 0008, 0009, 0010 are newest
-    assert.deepEqual(
-      recent.map((t) => t.id).sort(),
-      ["0008", "0009", "0010"]
-    );
+    assert.deepEqual(recent.map((t) => t.id).sort(), ["0008", "0009", "0010"]);
   });
 
   it("loadRecent with limit=0 returns all tasks", () => {
@@ -406,19 +400,13 @@ describe("parseTaskIdFromFilename", () => {
   });
 
   it("accepts 14-digit timestamp filenames", () => {
-    assert.equal(
-      parseTaskIdFromFilename("20260413120000-title.md"),
-      "20260413120000"
-    );
+    assert.equal(parseTaskIdFromFilename("20260413120000-title.md"), "20260413120000");
   });
 
   it("rejects ULIDs containing excluded chars (I/L/O/U)", () => {
     // 26 chars but includes forbidden letters — must be rejected to keep
     // lookup/list behavior consistent with the ULID generator's strictness.
-    assert.equal(
-      parseTaskIdFromFilename("01ARZ3NDLKTSV4RRGSSFQ9XNHY-x.md"),
-      null
-    );
+    assert.equal(parseTaskIdFromFilename("01ARZ3NDLKTSV4RRGSSFQ9XNHY-x.md"), null);
   });
 
   it("rejects non-task markdown filenames", () => {

--- a/src/tests/ulid.test.ts
+++ b/src/tests/ulid.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import {
-  generateUlid,
-  isValidUlid,
-  decodeTime,
-  _resetMonotonicState,
-} from "../ulid.js";
+import { generateUlid, isValidUlid, decodeTime, _resetMonotonicState } from "../ulid.js";
 
 describe("generateUlid", () => {
   beforeEach(() => {
@@ -114,28 +109,16 @@ describe("decodeTime", () => {
   });
 
   it("throws on invalid characters", () => {
-    assert.throws(
-      () => decodeTime("!1ARZ3NDEKTSV4RRGSSFQ9XNHY"),
-      /Invalid ULID character/
-    );
+    assert.throws(() => decodeTime("!1ARZ3NDEKTSV4RRGSSFQ9XNHY"), /Invalid ULID character/);
   });
 
   it("rejects Crockford ambiguity characters I/L/O (canonical-strict)", () => {
     // We're the sole ULID producer, so a ULID arriving with one of these
     // letters is either corrupted or hand-edited. Match isValidUlid's
     // strictness instead of silently translating I→1 / L→1 / O→0.
-    assert.throws(
-      () => decodeTime("01ARZ3NDLKTSV4RRGSSFQ9XNHY"),
-      /Invalid ULID character/
-    );
-    assert.throws(
-      () => decodeTime("01ARZ3NDIKTSV4RRGSSFQ9XNHY"),
-      /Invalid ULID character/
-    );
-    assert.throws(
-      () => decodeTime("01ARZ3NDOKTSV4RRGSSFQ9XNHY"),
-      /Invalid ULID character/
-    );
+    assert.throws(() => decodeTime("01ARZ3NDLKTSV4RRGSSFQ9XNHY"), /Invalid ULID character/);
+    assert.throws(() => decodeTime("01ARZ3NDIKTSV4RRGSSFQ9XNHY"), /Invalid ULID character/);
+    assert.throws(() => decodeTime("01ARZ3NDOKTSV4RRGSSFQ9XNHY"), /Invalid ULID character/);
   });
 });
 

--- a/src/tests/vector-store.test.ts
+++ b/src/tests/vector-store.test.ts
@@ -84,10 +84,7 @@ describe("VectorIndex", () => {
   });
 
   it("throws on a non-finite value in a corpus vector", () => {
-    assert.throws(
-      () => new VectorIndex([{ task: task("a"), vector: [1, NaN, 3] }]),
-      /Non-finite/
-    );
+    assert.throws(() => new VectorIndex([{ task: task("a"), vector: [1, NaN, 3] }]), /Non-finite/);
   });
 
   it("rejects a non-positive limit", () => {


### PR DESCRIPTION
## Summary

Adopts **[Biome](https://biomejs.dev)** — a single, fast (Rust) tool that replaces *both* Prettier (formatter) and ESLint (linter) — and wires a lint+format gate into CI. This is the "more modern than Prettier/ESLint" option requested.

Regenerated on top of `main` after #23 merged, so the repo-wide reformat also covers the semantic-search code.

## Config decisions

`biome.json` tuned to the existing house style (line width 100, es5 trailing commas, double quotes). Rules turned **off** because they fight deliberate, repeated patterns rather than catch bugs:

| Rule | Why off |
|---|---|
| `complexity/useLiteralKeys` | deliberate bracket access on index-signature objects (`meta["title"]`, `args["priority"]`); plays nicer with `noPropertyAccessFromIndexSignature` |
| `style/useTemplate` | multi-line error messages use `+` concatenation intentionally |
| `style/noNonNullAssertion` | stylistic; used judiciously |
| `assist/source/organizeImports` | keep the author's logical import grouping instead of alphabetizing |

Two intentional spots are suppressed inline (rule kept active elsewhere): the control-char **sanitizer** regex in `output.ts` (stripping control bytes is the point) and the canonical `while ((m = re.exec()))` iteration in `lint/collect.ts`.

## CI

`ci.yml` gains a dedicated **`lint`** job (single Node version, parallel with the existing test matrix) running `biome ci .`. The existing `tsc --noEmit` + build + test + pack gates are unchanged.

```bash
npm run check      # biome check .  (lint + format, what CI runs)
npm run check:fix  # auto-fix
npm run format
npm run lint
```

## Verification

`biome ci .` clean (62 files), `tsc --noEmit` clean, **416/416 tests pass**. Biome (`@biomejs/biome`) is a devDependency only — no runtime footprint.